### PR TITLE
fix: correction de 10 bugs (API, frontend, packages)

### DIFF
--- a/api/src/core/users/guards/user-roles.guard.ts
+++ b/api/src/core/users/guards/user-roles.guard.ts
@@ -41,7 +41,8 @@ export class UserRolesGuard implements CanActivate {
     if (!authorizedRoles) return true;
     const request = context.switchToHttp().getRequest();
 
-    // Request.user is the user, so we can directly access its roles
+    if (!request.user) return false;
+
     const roles = request.user.roles;
 
     return this.matchRoles(authorizedRoles, roles);

--- a/api/src/core/users/services/user.service.ts
+++ b/api/src/core/users/services/user.service.ts
@@ -83,6 +83,11 @@ export class UserService extends BaseService<User, UserRepository> {
     if (!user) {
       throw new NotFoundException("L`utilisateur n'a pas été trouvé");
     }
+    if (!user.userJwt) {
+      throw new InternalServerErrorException(
+        "L'association UserJwt est manquante pour cet utilisateur",
+      );
+    }
     const userJwt = user.userJwt;
 
     if (!user.resetPasswordOngoing) {
@@ -122,6 +127,11 @@ export class UserService extends BaseService<User, UserRepository> {
     const user = await this.findOne(userId);
     if (!user) {
       throw new NotFoundException("L`utilisateur n'a pas été trouvé");
+    }
+    if (!user.userJwt) {
+      throw new InternalServerErrorException(
+        "L'association UserJwt est manquante pour cet utilisateur",
+      );
     }
 
     const userJwt = user.userJwt;
@@ -336,8 +346,12 @@ export class UserService extends BaseService<User, UserRepository> {
     );
 
     // keep admin role for an admin, in case of mistake
-    if (isAdminUser && newUserHaveNotAdminRole)
-      dtoToBeUpdated.roles?.unshift(UserRoleEnum.Admin);
+    if (isAdminUser && newUserHaveNotAdminRole && dtoToBeUpdated.roles) {
+      dtoToBeUpdated = {
+        ...dtoToBeUpdated,
+        roles: [UserRoleEnum.Admin, ...dtoToBeUpdated.roles],
+      };
+    }
 
     const updatedDto = {
       ...existingDto,

--- a/api/src/general/auth-jwt/controllers/auth-jwt.controller.ts
+++ b/api/src/general/auth-jwt/controllers/auth-jwt.controller.ts
@@ -82,7 +82,7 @@ export class AuthJwtController extends BaseController {
       body.username,
       body.password,
     );
-    if (!user) throw new HttpException('Wrong credentials', 403);
+    if (!user) throw new UnauthorizedException('Wrong credentials');
 
     // Générer et retourner le token JWT
     const jwt = this.usersService.login(user);

--- a/api/src/utils/repositories/base.repositories.ts
+++ b/api/src/utils/repositories/base.repositories.ts
@@ -320,15 +320,17 @@ export class BaseRepository<
         // Special cases for: CONTAINS, IN, EXISTS, NOT EXISTS, IS NULL
         // We will override the standard case values
         if (cond.operator === OperatorEnum.CONTAINS && cond.key) {
-          // If the value is a string, we will cast the db array to text[] to avoid type issues
-          // If it is not, we do nothing and assume the user knows what he is doing
-          if (typeof cond.value === 'string') {
-            formattedTableNameAndCondKey = `${formattedTableNameAndCondKey}::text[]`;
+          const isSqlite = (process.env.DB_TYPE || '').includes('sqlite');
+          if (isSqlite) {
+            whereContent = `',' || ${formattedTableNameAndCondKey} || ',' LIKE :${myCondName}`;
+            whereOptions[myCondName] = `%,${cond.value},%`;
+          } else {
+            if (typeof cond.value === 'string') {
+              formattedTableNameAndCondKey = `${formattedTableNameAndCondKey}::text[]`;
+            }
+            whereContent = `${formattedTableNameAndCondKey} @> ARRAY [:${myCondName}]`;
+            whereOptions[myCondName] = cond.value;
           }
-
-          //whereContent = `${formattedTableNameAndCondKey} @> '{":${myCondName}"}'`;
-          whereContent = `${formattedTableNameAndCondKey} @> ARRAY [:${myCondName}]`;
-          whereOptions[myCondName] = cond.value;
         } else if (cond.operator === OperatorEnum.IN && cond.key) {
           if (!Array.isArray(cond.value)) {
             throw new Error('Value should be an array for IN operator');
@@ -336,12 +338,14 @@ export class BaseRepository<
 
           whereContent = `${formattedTableNameAndCondKey} IN (:...${myCondName})`;
           whereOptions[myCondName] = cond.value;
-        } else if (
-          cond.operator === OperatorEnum.EXISTS ||
-          cond.operator === OperatorEnum.NOT_EXISTS ||
-          cond.operator === OperatorEnum.IS_NULL
-        ) {
-          whereContent = `${formattedTableNameAndCondKey} ${cond.operator}`;
+        } else if (cond.operator === OperatorEnum.IS_NULL) {
+          whereContent = `${formattedTableNameAndCondKey} IS NULL`;
+          whereOptions = undefined;
+        } else if (cond.operator === OperatorEnum.EXISTS) {
+          whereContent = `${formattedTableNameAndCondKey} IS NOT NULL`;
+          whereOptions = undefined;
+        } else if (cond.operator === OperatorEnum.NOT_EXISTS) {
+          whereContent = `${formattedTableNameAndCondKey} IS NULL`;
           whereOptions = undefined;
         }
 

--- a/front/src/pages/auth/resetPassword/Index.vue
+++ b/front/src/pages/auth/resetPassword/Index.vue
@@ -71,6 +71,7 @@
                 size="1.0rem"
                 :label="'Appliquer le nouveau mot de passe'"
                 :loading="state.loading"
+                @click="methods.submitNewPassword"
               />
             </div>
           </q-form>
@@ -105,6 +106,7 @@ export default defineComponent({
       form: {
         login: null,
         password: null,
+        passwordConfirm: null,
       },
     });
 
@@ -153,7 +155,7 @@ export default defineComponent({
       },
     };
 
-    return { state, rules, i18n, props, stateless };
+    return { state, rules, i18n, props, stateless, methods };
   },
 });
 </script>

--- a/packages/core/src/statistics/period-calculator.ts
+++ b/packages/core/src/statistics/period-calculator.ts
@@ -121,19 +121,19 @@ export function unionPeriods(
   // Sort by start time
   allPeriods.sort((a, b) => a.start.getTime() - b.start.getTime());
 
-  // Merge overlapping periods
-  const merged: IPeriod[] = [allPeriods[0]];
+  // Merge overlapping periods (clone to avoid mutating inputs)
+  const merged: IPeriod[] = [
+    { start: new Date(allPeriods[0].start.getTime()), end: new Date(allPeriods[0].end.getTime()) },
+  ];
 
   for (let i = 1; i < allPeriods.length; i++) {
     const current = allPeriods[i];
     const last = merged[merged.length - 1];
 
     if (current.start <= last.end) {
-      // Overlapping or adjacent, merge
       last.end = new Date(Math.max(last.end.getTime(), current.end.getTime()));
     } else {
-      // Non-overlapping, add as new period
-      merged.push(current);
+      merged.push({ start: new Date(current.start.getTime()), end: new Date(current.end.getTime()) });
     }
   }
 

--- a/packages/core/src/validation/observation.validation.ts
+++ b/packages/core/src/validation/observation.validation.ts
@@ -120,10 +120,10 @@ export function validateReadings(readings: IReading[]): IValidationResult {
     );
   }
 
-  // Validate chronological order
+  // Validate chronological order (use last STOP, consistent with statistics)
   if (hasStart && hasStop) {
     const startReading = readings.find((r) => r.type === ReadingTypeEnum.START);
-    const stopReading = readings.find((r) => r.type === ReadingTypeEnum.STOP);
+    const stopReading = [...readings].reverse().find((r) => r.type === ReadingTypeEnum.STOP);
 
     if (startReading && stopReading && startReading.dateTime >= stopReading.dateTime) {
       errors.push(

--- a/packages/graph/src/pixi-app/data-area/index.ts
+++ b/packages/graph/src/pixi-app/data-area/index.ts
@@ -266,7 +266,9 @@ export class DataArea extends BaseGroup {
 
     if (stopReading) {
       for (const categoryEntry of this.readingsPerCategory) {
-        if (categoryEntry.category.action === ProtocolItemActionEnum.Continuous) {
+        const isContinuous = !categoryEntry.category.action ||
+          categoryEntry.category.action === ProtocolItemActionEnum.Continuous;
+        if (isContinuous) {
           categoryEntry.readings.push(stopReading);
         }
       }

--- a/packages/graph/src/pixi-app/index.ts
+++ b/packages/graph/src/pixi-app/index.ts
@@ -4,6 +4,7 @@ import { YAxis } from './axis/y-axis';
 import { DataArea } from './data-area';
 import type { IObservation, IProtocol, IGraphPreferences, IProtocolItem } from '@actograph/core';
 import { getObservableGraphPreferences } from '../utils/protocol.utils';
+import { clearPatternTextureCache } from '../lib/pattern-textures';
 
 interface IPixiAppInitOptions {
   view: HTMLCanvasElement;
@@ -610,6 +611,7 @@ export class PixiApp {
       this.app.canvas.removeEventListener('touchend', handlers.touchend);
       this.app.canvas.removeEventListener('touchcancel', handlers.touchcancel);
     }
+    clearPatternTextureCache();
     this.app.destroy();
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Résumé

Recherche systématique de bugs et correction de 10 problèmes identifiés à travers l'API, le frontend et les packages partagés.

## Bugs corrigés

### Frontend
- **Page Reset Password non-fonctionnelle** : ajout du handler `@click` manquant sur le bouton, retour de `methods` depuis `setup()`, et ajout de `passwordConfirm` dans l'état initial du formulaire

### API
- **Mauvais code HTTP 403 → 401** : `postLogin` retournait `403 Forbidden` au lieu de `401 Unauthorized` pour des identifiants incorrects
- **UserRolesGuard crash** : ajout d'un null-check sur `request.user` pour éviter un crash quand le guard est utilisé sans `JwtAuthGuard`
- **Opérateur CONTAINS incompatible SQLite** : la syntaxe PostgreSQL `@> ARRAY[...]` ne fonctionne pas avec `better-sqlite3` ; ajout d'un fallback `LIKE` pour SQLite
- **Opérateurs EXISTS/NOT_EXISTS invalides** : produisaient du SQL invalide (`column EXISTS`) ; mappés vers `IS NOT NULL` / `IS NULL`
- **Null-check userJwt manquant** : `chooseNewPasswordAfterReset` et `askForResetPassword` accédaient à `user.userJwt.id` sans vérifier que `userJwt` existe
- **Mutation du DTO dans updateAdmin** : `roles.unshift()` mutait le DTO d'entrée ; remplacé par une copie immutable

### Packages/core
- **`unionPeriods` mutait les objets d'entrée** : les périodes sont maintenant clonées avant fusion pour éviter de corrompre les données de l'appelant
- **Validation utilisant le premier STOP** : la validation utilisait `find()` (premier STOP) au lieu de `reverse().find()` (dernier STOP), incohérent avec les calculs de statistiques

### Packages/graph
- **Catégories continues avec `action === undefined`** : ces catégories ne recevaient pas le reading STOP, coupant la dernière portion du graphe. Alignement avec la logique de core (`!action || action === Continuous`)
- **Fuite mémoire du cache de textures** : `clearPatternTextureCache()` n'était jamais appelé ; ajouté dans `PixiApp.destroy()`

## Tests
- ✅ `packages/core` : 45/45 tests passent
- ✅ `front` : lint propre (0 erreur)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b063d94-1cf3-4c37-a0a6-471372fe20f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b063d94-1cf3-4c37-a0a6-471372fe20f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

