### PR TITLE
fix: harden popout window synchronization

### DIFF
--- a/front/src/composables/use-observation/index.ts
+++ b/front/src/composables/use-observation/index.ts
@@ -1,14 +1,11 @@
-import { reactive, ref, computed, watch } from 'vue';
+import { reactive, computed, watch } from 'vue';
 import {
   IObservation,
-  IProtocol,
   IReading,
   ObservationModeEnum,
   ReadingTypeEnum,
 } from '@services/observations/interface';
 import { observationService } from '@services/observations/index.service';
-import { readingService } from '@services/observations/reading.service';
-import { protocolService } from '@services/observations/protocol.service';
 import { useProtocol } from './use-protocol';
 import { useReadings } from './use-readings';
 import { useDuration } from '../use-duration';
@@ -18,18 +15,38 @@ import { useWindowSync } from '../use-window-sync';
 const sharedState = reactive({
   loading: false,
   currentObservation: null as IObservation | null,
-  // Timer state
   isPlaying: false,
   elapsedTime: 0,
   startTime: null as number | null,
   currentDate: null as Date | null,
 });
 
-// For timer functionality
 let intervalId: number | null = null;
-
-// Garde pour n'installer qu'une seule fois la synchronisation inter-fenêtres.
 let hasSetupObservationWindowSync = false;
+let followerObservationMetaHydrated = false;
+
+type ObservationMetaPayload = Pick<
+  IObservation,
+  'id' | 'name' | 'description' | 'videoPath' | 'mode'
+>;
+
+const buildObservationMetaPayload = (
+  observation: IObservation,
+): ObservationMetaPayload => ({
+  id: observation.id,
+  name: observation.name,
+  description: observation.description,
+  videoPath: observation.videoPath,
+  mode: observation.mode,
+});
+
+const isObservationMetaPayload = (
+  payload: unknown,
+): payload is ObservationMetaPayload => {
+  if (!payload || typeof payload !== 'object') return false;
+  const candidate = payload as Partial<ObservationMetaPayload>;
+  return typeof candidate.id === 'number';
+};
 
 export const useObservation = (options?: { init?: boolean }) => {
   const { init = false } = options || {};
@@ -42,42 +59,47 @@ export const useObservation = (options?: { init?: boolean }) => {
     sharedStateFromObservation: sharedState,
   });
 
-  // This is called only once when the composable is created at the application level
   if (init) {
-    // Nothing yet, but if we want to load on observation at startup it should be done here
+    // Nothing yet, but if we want to load one observation at startup it should be done here.
   }
 
-  // Duration composable
   const duration = useDuration();
+  const windowSync = useWindowSync();
 
-  // Timer related computed properties
-  const isActive = computed(() => sharedState.isPlaying || sharedState.elapsedTime > 0);
+  const isActive = computed(
+    () => sharedState.isPlaying || sharedState.elapsedTime > 0,
+  );
 
-  // Chronometer mode computed property
   const isChronometerMode = computed(() => {
     return sharedState.currentObservation?.mode === ObservationModeEnum.Chronometer;
   });
 
-  /**
-   * Détermine si on utilise le temps vidéo comme source de vérité pour elapsedTime
-   * En mode chronomètre avec vidéo, le VideoPlayer gère elapsedTime
-   */
   const usesVideoTime = computed(() => {
     return isChronometerMode.value && !!sharedState.currentObservation?.videoPath;
   });
 
-  /**
-   * Met à jour elapsedTime et currentDate depuis la source appropriée
-   * Cette méthode unifie la gestion du temps pour éviter les conflits
-   * 
-   * @param videoTime - Temps vidéo en secondes (optionnel)
-   *                    - Si fourni ET qu'on est en mode chronomètre avec vidéo : utilise ce temps
-   *                    - Si non fourni ET qu'on est en mode vidéo : ne fait rien (le temps vidéo est géré par handleTimeUpdate)
-   *                    - Si non fourni ET qu'on n'est PAS en mode vidéo : calcule depuis startTime
-   */
+  const broadcastObservationMeta = () => {
+    if (!sharedState.currentObservation?.id) return;
+    windowSync.broadcast(
+      'state:observation-meta',
+      buildObservationMetaPayload(sharedState.currentObservation),
+    );
+  };
+
+  const applyObservationMeta = (payload: ObservationMetaPayload) => {
+    const current = sharedState.currentObservation;
+    if (!current || current.id !== payload.id) return;
+
+    sharedState.currentObservation = {
+      ...current,
+      name: payload.name,
+      description: payload.description,
+      videoPath: payload.videoPath,
+      mode: payload.mode,
+    };
+  };
+
   const updateTimeFromSource = (videoTime?: number) => {
-    // Cas 1 : Mode chronomètre avec vidéo ET temps vidéo fourni
-    // C'est le cas quand VideoPlayer appelle cette méthode avec le temps actuel
     if (usesVideoTime.value && videoTime !== undefined) {
       sharedState.elapsedTime = videoTime;
       const t0 = chronometerMethods.getT0();
@@ -85,44 +107,31 @@ export const useObservation = (options?: { init?: boolean }) => {
       sharedState.currentDate = new Date(t0.getTime() + elapsedMs);
       return;
     }
-    
-    // Cas 2 : Mode normal (sans vidéo) ET timer démarré
-    // C'est le cas quand le timer interne appelle cette méthode sans paramètre
+
     if (!usesVideoTime.value && sharedState.startTime) {
       sharedState.elapsedTime = (Date.now() - sharedState.startTime) / 1000;
-      
-      // Update currentDate based on mode
+
       if (isChronometerMode.value) {
         const t0 = chronometerMethods.getT0();
         const elapsedMs = sharedState.elapsedTime * 1000;
         sharedState.currentDate = new Date(t0.getTime() + elapsedMs);
       } else {
-        sharedState.currentDate = new Date(sharedState.startTime + sharedState.elapsedTime * 1000);
+        sharedState.currentDate = new Date(
+          sharedState.startTime + sharedState.elapsedTime * 1000,
+        );
       }
-      return;
     }
-    
-    // Cas 3 : Mode vidéo mais pas de temps fourni
-    // Le timer appelle cette méthode mais on est en mode vidéo
-    // On ne fait rien car le temps est géré par handleTimeUpdate du VideoPlayer
-    // C'est le comportement attendu pour éviter les conflits
   };
 
-  // Timer methods
   const timerMethods = {
     startTimer: () => {
-      // Idempotence basée sur l'état partagé (et non sur l'interval), car
-      // l'interval d'affichage est désormais piloté par un watch sur
-      // `isPlaying` et tourne dans chaque fenêtre.
       if (sharedState.isPlaying) return;
 
-      // Decide start/resume from timeline state, not from raw readings count.
-      // This avoids getting stuck without START when data readings already exist.
       const startStopReadings = readings.sharedState.currentReadings.filter(
         (reading: IReading) => (
           reading.type === ReadingTypeEnum.START
           || reading.type === ReadingTypeEnum.STOP
-        )
+        ),
       );
       const lastStartStopReading = startStopReadings[startStopReadings.length - 1];
       const shouldCreateStartReading = !lastStartStopReading
@@ -131,28 +140,23 @@ export const useObservation = (options?: { init?: boolean }) => {
       if (shouldCreateStartReading) {
         readings.methods.addStartReading();
       } else {
-        // Resume flow (PAUSE_END may be skipped in video mode by design).
         readings.methods.addPauseEndReading();
       }
 
       const now = Date.now();
 
-      // If we're starting fresh (not resuming), set the current date
       if (!sharedState.startTime) {
-        // In chronometer mode, use t0 + elapsedTime
         if (isChronometerMode.value) {
           const t0 = chronometerMethods.getT0();
           const elapsedMs = sharedState.elapsedTime * 1000;
           sharedState.currentDate = new Date(t0.getTime() + elapsedMs);
         } else {
-        sharedState.currentDate = new Date();
+          sharedState.currentDate = new Date();
         }
       }
-      
+
       sharedState.startTime = now - sharedState.elapsedTime * 1000;
       sharedState.isPlaying = true;
-      // L'interval d'affichage est démarré par le watch sur `sharedState.isPlaying`
-      // installé dans setupObservationWindowSync() (s'exécute dans chaque fenêtre).
     },
 
     pauseTimer: () => {
@@ -161,8 +165,6 @@ export const useObservation = (options?: { init?: boolean }) => {
         intervalId = null;
       }
       sharedState.isPlaying = false;
-
-      // Add the start of the pause
       readings.methods.addPauseStartReading();
     },
 
@@ -172,7 +174,6 @@ export const useObservation = (options?: { init?: boolean }) => {
         intervalId = null;
       }
 
-      // Add the end of the chronique
       readings.methods.addStopReading();
 
       sharedState.isPlaying = false;
@@ -208,30 +209,11 @@ export const useObservation = (options?: { init?: boolean }) => {
     },
   };
 
-  // Chronometer methods
   const chronometerMethods = {
-    /**
-     * Retourne la date de référence (t0) pour le mode chronomètre.
-     * 
-     * Cette méthode retourne la constante CHRONOMETER_T0 définie dans
-     * @utils/chronometer.constants.ts (9 février 1989 à 00:00:00.000 UTC).
-     * 
-     * @returns Date de référence t0 pour les calculs de durée en mode chronomètre
-     */
     getT0: (): Date => {
       return CHRONOMETER_T0;
     },
 
-    /**
-     * Convertit une date en durée (millisecondes) depuis t0.
-     * 
-     * Cette méthode calcule la différence entre la date fournie et la date de référence
-     * CHRONOMETER_T0 (définie dans @utils/chronometer.constants.ts).
-     * 
-     * @param date - Date à convertir en durée
-     * @returns Durée en millisecondes depuis t0
-     * @throws Error si on n'est pas en mode chronomètre
-     */
     dateToDuration: (date: Date): number => {
       if (!isChronometerMode.value) {
         throw new Error('Cannot convert date to duration: not in chronometer mode');
@@ -239,16 +221,6 @@ export const useObservation = (options?: { init?: boolean }) => {
       return duration.dateToDuration(date, CHRONOMETER_T0);
     },
 
-    /**
-     * Convertit une durée (millisecondes) en date en l'ajoutant à t0.
-     * 
-     * Cette méthode ajoute la durée fournie à la date de référence CHRONOMETER_T0
-     * (définie dans @utils/chronometer.constants.ts) pour obtenir une date absolue.
-     * 
-     * @param milliseconds - Durée en millisecondes depuis t0
-     * @returns Date correspondant à t0 + durée
-     * @throws Error si on n'est pas en mode chronomètre
-     */
     durationToDate: (milliseconds: number): Date => {
       if (!isChronometerMode.value) {
         throw new Error('Cannot convert duration to date: not in chronometer mode');
@@ -256,17 +228,6 @@ export const useObservation = (options?: { init?: boolean }) => {
       return duration.durationToDate(milliseconds, CHRONOMETER_T0);
     },
 
-    /**
-     * Formate une date comme une chaîne de durée (format compact).
-     * 
-     * Cette méthode calcule la durée entre la date fournie et la date de référence
-     * CHRONOMETER_T0 (définie dans @utils/chronometer.constants.ts), puis formate
-     * cette durée au format compact (ex: "2j 3h 15m 30s 500ms").
-     * 
-     * @param date - Date à formater comme durée
-     * @returns Chaîne de durée formatée (format compact)
-     * @throws Error si on n'est pas en mode chronomètre
-     */
     formatDateAsDuration: (date: Date): string => {
       if (!isChronometerMode.value) {
         throw new Error('Cannot format date as duration: not in chronometer mode');
@@ -277,15 +238,13 @@ export const useObservation = (options?: { init?: boolean }) => {
 
   const methods = {
     cloneExampleObservation: async () => {
-      const exampleObservation =
-        await observationService.cloneExampleObservation();
-      return exampleObservation;
+      return await observationService.cloneExampleObservation();
     },
+
     cloneExampleObservationByKey: async (exampleKey: string) => {
-      const exampleObservation =
-        await observationService.cloneExampleObservationByKey(exampleKey);
-      return exampleObservation;
+      return await observationService.cloneExampleObservationByKey(exampleKey);
     },
+
     loadObservation: async (id: number) => {
       sharedState.loading = true;
       try {
@@ -296,6 +255,7 @@ export const useObservation = (options?: { init?: boolean }) => {
         throw error;
       }
     },
+
     createObservation: async (options: {
       name: string;
       description?: string;
@@ -303,11 +263,9 @@ export const useObservation = (options?: { init?: boolean }) => {
       mode?: ObservationModeEnum;
     }) => {
       const response = await observationService.create(options);
-      
-      // Load the full observation (with readings and protocol)
-      // The response from create might not have all relations loaded
       await methods.loadObservation(response.id);
     },
+
     updateObservation: async (id: number, updateData: {
       name?: string;
       description?: string;
@@ -315,12 +273,14 @@ export const useObservation = (options?: { init?: boolean }) => {
       mode?: ObservationModeEnum;
     }) => {
       const response = await observationService.update(id, updateData);
-      // Reload the observation to get updated data
       await methods.loadObservation(id);
+      broadcastObservationMeta();
       return response;
     },
+
     closeObservation: () => {
-      useWindowSync().setObservationId(null);
+      windowSync.setObservationId(null);
+      followerObservationMetaHydrated = false;
 
       if (intervalId) {
         clearInterval(intervalId);
@@ -336,9 +296,9 @@ export const useObservation = (options?: { init?: boolean }) => {
       readings.sharedState.currentReadings = [];
       protocol.sharedState.currentProtocol = null;
     },
+
     _loadObservation: async (observation: IObservation) => {
-      // Renseigner l'observation suivie pour le filtrage des messages inter-fenêtres.
-      useWindowSync().setObservationId(observation?.id ?? null);
+      windowSync.setObservationId(observation?.id ?? null);
       sharedState.loading = true;
       sharedState.currentObservation = null;
       readings.sharedState.currentReadings = [];
@@ -354,22 +314,9 @@ export const useObservation = (options?: { init?: boolean }) => {
     },
   };
 
-  // ----------------------------------------------------------------------
-  // Synchronisation inter-fenêtres (BroadcastChannel)
-  // ----------------------------------------------------------------------
-  const windowSync = useWindowSync();
-
   if (!hasSetupObservationWindowSync) {
     hasSetupObservationWindowSync = true;
 
-    // Note: ce setup est déclenché par le premier appel à useObservation(), qui
-    // provient de pages/Index.vue (racine, jamais démontée). Les watchers vivent
-    // donc pour toute la durée de la fenêtre.
-
-    // 1) Interval d'affichage du temps, piloté par `isPlaying`, dans CHAQUE
-    //    fenêtre. En mode non-vidéo, chaque fenêtre dérive elapsedTime depuis
-    //    `startTime` (partagé) ; en mode vidéo, l'interval est inerte et le
-    //    temps provient de la fenêtre vidéo via diffusion.
     watch(
       () => sharedState.isPlaying,
       (playing) => {
@@ -386,18 +333,9 @@ export const useObservation = (options?: { init?: boolean }) => {
           intervalId = null;
         }
       },
-      { immediate: true }
+      { immediate: true },
     );
 
-    // 2) Diffusion de l'état temporel.
-    //    Le payload contient toujours les 4 champs, mais la STRATÉGIE diffère :
-    //    - Changements structurels (isPlaying / startTime) : diffusion immédiate
-    //      (événements rares : start / pause / stop). Le snapshot d'elapsedTime
-    //      qu'ils transportent permet de propager les états figés (pause/stop/reset).
-    //    - Mode vidéo uniquement : diffusion throttlée d'elapsedTime / currentDate,
-    //      car la fenêtre vidéo fait autorité sur le temps. En mode non-vidéo, le
-    //      temps n'est PAS diffusé pendant la lecture : chaque fenêtre le dérive
-    //      localement depuis startTime (évite tout jitter).
     let lastObsBroadcast = 0;
     let obsBroadcastTimer: number | null = null;
     const OBS_THROTTLE_MS = 100;
@@ -428,7 +366,6 @@ export const useObservation = (options?: { init?: boolean }) => {
       }
     };
 
-    // Changements structurels : diffusion immédiate.
     watch(
       () => [sharedState.isPlaying, sharedState.startTime] as const,
       () => {
@@ -439,29 +376,41 @@ export const useObservation = (options?: { init?: boolean }) => {
           obsBroadcastTimer = null;
         }
         broadcastObservationState();
-      }
+      },
     );
 
-    // Temps vidéo : diffusion throttlée (uniquement en mode vidéo).
     watch(
       () => [sharedState.elapsedTime, sharedState.currentDate] as const,
       () => {
         if (windowSync.isApplyingRemote()) return;
         if (!usesVideoTime.value) return;
         scheduleObservationBroadcast();
-      }
+      },
     );
 
-    // 3) Réception de l'état temporel d'une autre fenêtre.
+    watch(
+      () => [
+        sharedState.currentObservation?.id,
+        sharedState.currentObservation?.name,
+        sharedState.currentObservation?.description,
+        sharedState.currentObservation?.videoPath,
+        sharedState.currentObservation?.mode,
+      ] as const,
+      () => {
+        if (windowSync.isApplyingRemote()) return;
+        if (!sharedState.currentObservation?.id) return;
+        if (!windowSync.isOwner && !followerObservationMetaHydrated) return;
+        broadcastObservationMeta();
+      },
+    );
+
     windowSync.on('state:observation', (payload: Record<string, unknown>) => {
       if (!payload) return;
       windowSync.applyRemote(() => {
         sharedState.isPlaying = !!payload.isPlaying;
         sharedState.startTime =
           typeof payload.startTime === 'number' ? payload.startTime : null;
-        // Appliquer le temps si la vidéo fait autorité (mode vidéo) OU si on
-        // n'est pas en lecture (états figés : pause / stop / reset). En lecture
-        // non-vidéo, chaque fenêtre dérive elapsedTime depuis startTime.
+
         const applyTime = usesVideoTime.value || !sharedState.isPlaying;
         if (applyTime) {
           if (typeof payload.elapsedTime === 'number') {
@@ -476,20 +425,25 @@ export const useObservation = (options?: { init?: boolean }) => {
       });
     });
 
-    // 4) Rediffusion locale de l'événement "boutons actifs" calculé par la
-    //    fenêtre vidéo, pour que la fenêtre des boutons (où qu'elle soit) le
-    //    reçoive. On redispatch un CustomEvent identique à celui émis en local
-    //    afin que les écouteurs existants fonctionnent sans modification.
+    windowSync.on('state:observation-meta', (payload: unknown) => {
+      if (!isObservationMetaPayload(payload)) return;
+      if (!windowSync.isOwner) followerObservationMetaHydrated = true;
+      windowSync.applyRemote(() => {
+        applyObservationMeta(payload);
+      });
+    });
+
     windowSync.on('event:video-reading-active', (payload) => {
       if (typeof window === 'undefined') return;
       window.dispatchEvent(
-        new CustomEvent('video-reading-active', { detail: payload })
+        new CustomEvent('video-reading-active', { detail: payload }),
       );
     });
 
-    // 5) L'owner répond aux demandes d'hydratation des fenêtres pop-out.
     windowSync.on('hydrate:request', () => {
-      if (windowSync.isOwner) broadcastObservationState();
+      if (!windowSync.isOwner) return;
+      broadcastObservationState();
+      broadcastObservationMeta();
     });
   }
 
@@ -503,8 +457,6 @@ export const useObservation = (options?: { init?: boolean }) => {
     duration,
     isActive,
     isChronometerMode,
-    // Méthode unifiée pour mettre à jour le temps depuis n'importe quelle source
-    // (VideoPlayer ou timer interne)
     updateTimeFromSource,
   };
 };

--- a/front/src/composables/use-observation/index.ts
+++ b/front/src/composables/use-observation/index.ts
@@ -273,7 +273,20 @@ export const useObservation = (options?: { init?: boolean }) => {
       mode?: ObservationModeEnum;
     }) => {
       const response = await observationService.update(id, updateData);
-      await methods.loadObservation(id);
+
+      // Ne pas recharger toute l'observation ici : dans une fenêtre pop-out déjà
+      // hydratée, un reload complet peut rediffuser des relevés persistés mais
+      // plus vieux que l'état vivant de l'owner. On applique uniquement les
+      // métadonnées mises à jour, puis on les propage aux autres fenêtres.
+      if (sharedState.currentObservation?.id === id) {
+        sharedState.currentObservation = {
+          ...sharedState.currentObservation,
+          ...response,
+        };
+      } else {
+        await methods.loadObservation(id);
+      }
+
       broadcastObservationMeta();
       return response;
     },

--- a/front/src/composables/use-popout/index.ts
+++ b/front/src/composables/use-popout/index.ts
@@ -11,6 +11,8 @@
  * - `popout:opened` / `popout:alive` : un panneau est ouvert dans une fenêtre
  *   séparée (heartbeat régulier pour détecter une fermeture brutale).
  * - `popout:closed` : la fenêtre pop-out se ferme proprement.
+ * - `popout:close-requested` : l'owner demande à la fenêtre pop-out de se fermer,
+ *   même si la référence `Window` locale a été perdue après un refresh.
  *
  * Un nettoyage par expiration (staleness) côté owner réintègre le panneau si la
  * fenêtre pop-out a disparu sans envoyer `popout:closed` (crash, kill, etc.).
@@ -61,7 +63,10 @@ const ensureInitialized = () => {
     if (isPopoutComponent(payload?.component)) markSeen(payload.component);
   });
   windowSync.on('popout:closed', (payload: { component?: unknown }) => {
-    if (isPopoutComponent(payload?.component)) sharedState[payload.component] = false;
+    if (isPopoutComponent(payload?.component)) {
+      sharedState[payload.component] = false;
+      lastSeen[payload.component] = 0;
+    }
   });
 
   // Réintégration automatique si une fenêtre pop-out disparaît sans prévenir.
@@ -75,6 +80,7 @@ const ensureInitialized = () => {
           now - lastSeen[component] > STALE_TIMEOUT_MS
         ) {
           sharedState[component] = false;
+          lastSeen[component] = 0;
         }
       });
     }, HEARTBEAT_INTERVAL_MS);
@@ -95,7 +101,13 @@ export const usePopout = () => {
   /** Marque (et diffuse) la fermeture d'un panneau incrusté. */
   const markClosed = (component: PopoutComponent) => {
     sharedState[component] = false;
+    lastSeen[component] = 0;
     windowSync.broadcast('popout:closed', { component });
+  };
+
+  /** Demande à la fenêtre pop-out de se fermer elle-même. */
+  const requestClose = (component: PopoutComponent) => {
+    windowSync.broadcast('popout:close-requested', { component });
   };
 
   /** Signale que la fenêtre pop-out est toujours vivante (heartbeat). */
@@ -108,6 +120,7 @@ export const usePopout = () => {
     heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
     markOpened,
     markClosed,
+    requestClose,
     heartbeat,
   };
 };

--- a/front/src/composables/use-window-sync/index.ts
+++ b/front/src/composables/use-window-sync/index.ts
@@ -6,37 +6,22 @@
  * `BroadcastChannel`. Il permet à la fenêtre principale et aux fenêtres
  * "incrustées" (pop-out vidéo / boutons / relevés, ouvertes via `window.open`)
  * de partager l'état d'une observation sans passer par le backend.
- *
- * Topologie retenue :
- * - UNE fenêtre "propriétaire" (owner) : la fenêtre principale (toute fenêtre
- *   qui n'est pas sur une route `#/popup/...`). Elle seule écrit au backend
- *   (boucle de synchronisation des relevés) et fait autorité lors d'une
- *   demande d'hydratation.
- * - Des fenêtres "suiveuses" (followers) : les pop-out. Elles n'écrivent jamais
- *   au backend ; elles émettent des changements via le canal et appliquent les
- *   états reçus.
- *
- * Points clés de robustesse :
- * - Anti-écho : chaque message porte l'id de l'émetteur ; on ignore ses propres
- *   messages. De plus, un compteur de suppression (`applyRemote`) empêche les
- *   watchers d'intégration de re-diffuser un état que l'on vient d'appliquer.
- * - Clonage : `BroadcastChannel` utilise le structured clone, incompatible avec
- *   les proxies réactifs de Vue. On sérialise donc via un round-trip JSON
- *   (`safeClone`) ; les champs `Date` sont reconstruits côté récepteur par le
- *   code d'intégration.
  */
 import { nextTick, ref } from 'vue';
 import { v4 as uuidv4 } from 'uuid';
 
 export type WindowSyncMessageType =
   | 'state:observation'
+  | 'state:observation-meta'
   | 'state:readings'
   | 'state:protocol'
   | 'event:video-reading-active'
   | 'popout:opened'
   | 'popout:closed'
   | 'popout:alive'
-  | 'hydrate:request';
+  | 'popout:close-requested'
+  | 'hydrate:request'
+  | 'hydrate:complete';
 
 export interface WindowSyncMessage<T = unknown> {
   senderId: string;
@@ -49,10 +34,6 @@ type Handler = (payload: any, message: WindowSyncMessage) => void;
 
 const CHANNEL_NAME = 'actograph-window-sync';
 
-// Identité et rôle, figés pour toute la durée de vie de la fenêtre.
-// Une fenêtre pop-out charge directement la route `#/popup/...` et n'en sort
-// jamais ; la fenêtre principale n'est jamais sur cette route. La détection au
-// chargement est donc stable.
 const senderId = uuidv4();
 const isPopupWindow =
   typeof window !== 'undefined' &&
@@ -60,29 +41,15 @@ const isPopupWindow =
   window.location.hash.startsWith('#/popup/');
 const isOwner = !isPopupWindow;
 
-// Observation suivie par cette fenêtre (renseignée par le code d'intégration).
-// Sert à filtrer les messages concernant une autre observation.
 let currentObsId: number | null = null;
 const setObservationId = (id: number | null) => {
   currentObsId = id;
 };
 const getObservationId = () => currentObsId;
 
-// Compteur de suppression : tant qu'il est > 0, les watchers d'intégration ne
-// doivent PAS re-diffuser, car nous sommes en train d'appliquer un état reçu
-// d'une autre fenêtre (évite les boucles d'écho).
 const suppressDepth = ref(0);
 const isApplyingRemote = () => suppressDepth.value > 0;
 
-/**
- * Exécute `fn` (mutation locale d'un état partagé) en mode "application
- * distante" : pendant l'exécution et jusqu'au prochain flush des watchers Vue,
- * `isApplyingRemote()` renvoie `true`, ce qui inhibe la re-diffusion.
- *
- * La libération se fait via `nextTick` car les watchers Vue se déclenchent de
- * façon asynchrone (après la mutation synchrone), et doivent encore voir le
- * drapeau actif lors de leur flush.
- */
 const applyRemote = <T>(fn: () => T): T => {
   suppressDepth.value++;
   try {
@@ -104,7 +71,7 @@ const ensureChannel = (): BroadcastChannel | null => {
   channel.onmessage = (event: MessageEvent<WindowSyncMessage>) => {
     const message = event.data;
     if (!message || message.senderId === senderId) return;
-    // Filtrer les messages d'une autre observation lorsque les deux ids sont connus.
+
     if (
       message.obsId != null &&
       currentObsId != null &&
@@ -112,24 +79,30 @@ const ensureChannel = (): BroadcastChannel | null => {
     ) {
       return;
     }
+
     const set = handlers.get(message.type);
-    if (!set) return;
-    set.forEach((handler) => {
-      try {
-        handler(message.payload, message);
-      } catch (error) {
-        console.error(`[window-sync] handler error for "${message.type}"`, error);
-      }
-    });
+    if (set) {
+      set.forEach((handler) => {
+        try {
+          handler(message.payload, message);
+        } catch (error) {
+          console.error(`[window-sync] handler error for "${message.type}"`, error);
+        }
+      });
+    }
+
+    // Les composables owner répondent d'abord à `hydrate:request` avec leurs
+    // états respectifs. L'accusé part au tick suivant pour permettre aux pop-out
+    // de n'activer l'interface qu'après réception des snapshots vivants.
+    if (message.type === 'hydrate:request' && isOwner && typeof window !== 'undefined') {
+      window.setTimeout(() => {
+        broadcast('hydrate:complete', { observationId: currentObsId });
+      }, 0);
+    }
   };
   return channel;
 };
 
-/**
- * Sérialisation sûre pour `postMessage` : déproxifie les objets réactifs Vue et
- * produit une copie profonde clonable. Les `Date` deviennent des chaînes ISO et
- * sont reconstruites par le code d'intégration côté récepteur.
- */
 const safeClone = <T>(value: T): T => {
   if (value === undefined || value === null) return value;
   try {
@@ -155,10 +128,6 @@ const broadcast = (type: WindowSyncMessageType, payload?: unknown) => {
   }
 };
 
-/**
- * Abonne un handler à un type de message. Retourne une fonction de
- * désabonnement.
- */
 const on = (type: WindowSyncMessageType, handler: Handler): (() => void) => {
   ensureChannel();
   if (!handlers.has(type)) handlers.set(type, new Set());

--- a/front/src/pages/userspace/observation/Index.vue
+++ b/front/src/pages/userspace/observation/Index.vue
@@ -1,35 +1,6 @@
 <template>
   <DPage>
-    <!-- 
-      Structure principale de la page Observation
-      ===========================================
-      
-      Cette page gère deux modes d'affichage :
-      1. Mode avec vidéo : Splitter horizontal pour séparer la vidéo du reste du contenu
-      2. Mode sans vidéo : Affichage direct du contenu principal (boutons + relevés)
-      
-      Architecture des splitters :
-      - Splitter horizontal (vidéo) : Sépare la vidéo (haut) du contenu principal (bas)
-      - Splitter vertical (contenu) : Sépare les boutons (gauche) des relevés (droite)
-      
-      IMPORTANT : Le splitter horizontal nécessite une hauteur explicite en pixels pour
-      fonctionner correctement. Cette hauteur est calculée dynamiquement via ResizeObserver.
-    -->
     <div ref="containerRef" class="fit column no-wrap">
-      <!-- 
-        Mode avec vidéo : Splitter horizontal
-        ---------------------------------------
-        Affiché si :
-        - L'observation est en mode chronomètre, OU
-        - Une vidéo est chargée (videoPath existe)
-        
-        Le splitter horizontal permet de redimensionner la hauteur de la zone vidéo
-        en glissant le séparateur. La vidéo occupe le panneau "before" et le reste
-        du contenu (toolbar + boutons/relevés) occupe le panneau "after".
-        
-        IMPORTANT: Utilisation de v-show au lieu de v-if pour éviter les problèmes
-        de démontage rapide avec les directives Quasar (__qtouchpan).
-      -->
       <q-splitter
         v-show="observation.isChronometerMode.value || observation.sharedState.currentObservation?.videoPath"
         :key="`video-splitter-${observation.sharedState.currentObservation?.id || 'new'}`"
@@ -38,7 +9,6 @@
         :style="{ height: state.containerHeight + 'px', display: (observation.isChronometerMode.value || observation.sharedState.currentObservation?.videoPath) ? 'flex' : 'none' }"
         :limits="[10, 75]"
       >
-        <!-- Panneau supérieur : Lecteur vidéo -->
         <template v-slot:before>
           <div class="video-panel-wrapper column fit position-relative">
             <template v-if="!popout.sharedState.video">
@@ -68,8 +38,7 @@
             </div>
           </div>
         </template>
-        
-        <!-- Séparateur : Bouton de redimensionnement horizontal -->
+
         <template v-slot:separator>
           <q-avatar
             color="accent"
@@ -79,17 +48,14 @@
             class="video-resize-handle"
           />
         </template>
-        
-        <!-- Panneau inférieur : Contenu principal (toolbar + boutons/relevés) -->
+
         <template v-slot:after>
           <div class="fit column no-wrap">
-            <!-- Toolbar calendrier (affichée uniquement en mode calendrier) -->
             <CalendarToolbar
               v-if="!observation.isChronometerMode.value"
               class="col-auto"
             />
-            
-            <!-- Splitter vertical : Boutons (gauche) / Relevés (droite) -->
+
             <q-splitter
               v-model="state.splitterModel"
               class="col"
@@ -140,22 +106,14 @@
           </div>
         </template>
       </q-splitter>
-      
-      <!-- 
-        Mode sans vidéo : Affichage direct du contenu principal
-        --------------------------------------------------------
-        Affiché si aucune vidéo n'est chargée et que l'observation n'est pas en mode chronomètre.
-        Dans ce cas, on affiche directement la toolbar et le splitter vertical boutons/relevés.
-      -->
+
       <div
         v-show="!(observation.isChronometerMode.value || observation.sharedState.currentObservation?.videoPath)"
         class="fit column no-wrap"
         :style="{ display: !(observation.isChronometerMode.value || observation.sharedState.currentObservation?.videoPath) ? 'flex' : 'none' }"
       >
-        <!-- Toolbar calendrier -->
         <CalendarToolbar class="col-auto" />
-        
-        <!-- Splitter vertical : Boutons (gauche) / Relevés (droite) -->
+
         <q-splitter
           v-model="state.splitterModel"
           class="col"
@@ -215,7 +173,7 @@ import ReadingsSideIndex from './_components/readings-side/Index.vue';
 import CalendarToolbar from './_components/CalendarToolbar.vue';
 import VideoPlayer from './_components/VideoPlayer.vue';
 import { useObservation } from 'src/composables/use-observation';
-import { usePopout } from 'src/composables/use-popout';
+import { usePopout, PopoutComponent } from 'src/composables/use-popout';
 
 export default defineComponent({
   components: {
@@ -229,69 +187,45 @@ export default defineComponent({
     const observation = useObservation();
     const popout = usePopout();
     const containerRef = ref<HTMLElement | null>(null);
-    
+
     const state = reactive({
-      splitterModel: 40, // Vertical splitter for buttons/relevés (percentage)
-      videoSplitterModel: 25, // Horizontal splitter for video height (percentage of available height)
-      // IMPORTANT: containerHeight is required for q-splitter with horizontal orientation.
-      // Quasar's q-splitter needs an explicit height value (in pixels) to properly calculate
-      // and resize its panes when the user drags the separator. Without this, the splitter
-      // cannot determine how much space is available and will not resize correctly.
-      // The ResizeObserver below dynamically updates this value when the container size changes.
-      containerHeight: 600, // Default height, will be updated dynamically by ResizeObserver
+      splitterModel: 40,
+      videoSplitterModel: 25,
+      containerHeight: 600,
     });
 
-    // Références vers les fenêtres pop-out ouvertes, pour pouvoir les refermer
-    // (réintégration du panneau dans la fenêtre principale).
-    const popoutWindows: Record<'video' | 'buttons', Window | null> = {
+    const popoutWindows: Record<PopoutComponent, Window | null> = {
       video: null,
       buttons: null,
     };
 
-    const popOutVideo = () => {
+    const openPopout = (component: PopoutComponent, width: number, height: number) => {
       const observationId = observation.sharedState.currentObservation?.id;
       if (!observationId) return;
-      const width = 800;
-      const height = 600;
+
       const left = window.screenX + 50;
       const top = window.screenY + 50;
       const baseUrl = window.location.href.split('#')[0];
       const popup = window.open(
-        `${baseUrl}#/popup/video?observationId=${observationId}`,
-        'actograph-video',
-        `width=${width},height=${height},left=${left},top=${top},resizable=yes`
+        `${baseUrl}#/popup/${component}?observationId=${observationId}`,
+        `actograph-${component}`,
+        `width=${width},height=${height},left=${left},top=${top},resizable=yes`,
       );
-      // Marquer optimistiquement le panneau comme incrusté (confirmé ensuite par
-      // le heartbeat de la fenêtre pop-out, réintégré si elle se ferme).
+
       if (popup) {
-        popoutWindows.video = popup;
-        popout.markOpened('video');
+        popoutWindows[component] = popup;
+        popout.markOpened(component);
       }
     };
 
-    const popOutButtons = () => {
-      const observationId = observation.sharedState.currentObservation?.id;
-      if (!observationId) return;
-      const width = 400;
-      const height = 600;
-      const left = window.screenX + 50;
-      const top = window.screenY + 50;
-      const baseUrl = window.location.href.split('#')[0];
-      const popup = window.open(
-        `${baseUrl}#/popup/buttons?observationId=${observationId}`,
-        'actograph-buttons',
-        `width=${width},height=${height},left=${left},top=${top},resizable=yes`
-      );
-      if (popup) {
-        popoutWindows.buttons = popup;
-        popout.markOpened('buttons');
-      }
-    };
+    const popOutVideo = () => openPopout('video', 800, 600);
+    const popOutButtons = () => openPopout('buttons', 400, 600);
 
-    // Réintègre un panneau : ferme la fenêtre pop-out si on en a la référence,
-    // et lève le drapeau localement (la fenêtre pop-out diffusera aussi sa
-    // fermeture, et le heartbeat sert de filet de sécurité).
-    const bringBack = (component: 'video' | 'buttons') => {
+    // Réintègre un panneau. La demande BroadcastChannel couvre le cas où la
+    // fenêtre principale n'a plus la référence `Window` locale (refresh, reload).
+    const bringBack = (component: PopoutComponent) => {
+      popout.requestClose(component);
+
       const ref = popoutWindows[component];
       if (ref && !ref.closed) {
         try {
@@ -300,6 +234,7 @@ export default defineComponent({
           /* ignore */
         }
       }
+
       popoutWindows[component] = null;
       popout.markClosed(component);
     };
@@ -311,9 +246,6 @@ export default defineComponent({
       bringBackButtons: () => bringBack('buttons'),
     };
 
-    // Update container height dynamically
-    // This function is called by ResizeObserver whenever the container's size changes.
-    // It ensures that the q-splitter always has an accurate height value to work with.
     const updateContainerHeight = () => {
       if (containerRef.value) {
         const height = containerRef.value.clientHeight;
@@ -323,20 +255,11 @@ export default defineComponent({
       }
     };
 
-    // Set up ResizeObserver to watch for container size changes
-    // IMPORTANT: This ResizeObserver is CRITICAL for the q-splitter to function correctly.
-    // It watches the containerRef element and updates containerHeight whenever the size changes.
-    // This allows the splitter to properly resize its panes (video player and content area)
-    // when the user drags the separator handle. Without this observer, the splitter would
-    // have a fixed height and would not respond correctly to window resizing or dragging.
     let resizeObserver: ResizeObserver | null = null;
 
     onMounted(() => {
-      // Initial height calculation
       updateContainerHeight();
-      
-      // Create ResizeObserver to watch for size changes
-      // This ensures the splitter height stays synchronized with the actual container size
+
       if (containerRef.value) {
         resizeObserver = new ResizeObserver(() => {
           updateContainerHeight();
@@ -344,18 +267,14 @@ export default defineComponent({
         resizeObserver.observe(containerRef.value);
       }
 
-      // Also update on window resize as a fallback
-      // This handles cases where ResizeObserver might not fire (e.g., browser compatibility issues)
       window.addEventListener('resize', updateContainerHeight);
     });
 
     onUnmounted(() => {
-      // Clean up ResizeObserver to prevent memory leaks
       if (resizeObserver && containerRef.value) {
         resizeObserver.unobserve(containerRef.value);
         resizeObserver.disconnect();
       }
-      // Clean up window resize listener
       window.removeEventListener('resize', updateContainerHeight);
     });
 
@@ -388,4 +307,3 @@ export default defineComponent({
   text-align: center;
 }
 </style>
-

--- a/front/src/pages/userspace/observation/PopupView.vue
+++ b/front/src/pages/userspace/observation/PopupView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fit">
+  <div class="fit position-relative">
     <div v-if="state.loading" class="fit column items-center justify-center">
       <q-spinner color="primary" size="48px" />
       <div class="text-body2 q-mt-md text-grey">{{ $t('observation.popupLoading') }}</div>
@@ -8,12 +8,24 @@
       <q-icon name="error" size="48px" color="negative" />
       <div class="text-body1 q-mt-md text-negative">{{ state.error }}</div>
     </div>
-    <VideoPlayer v-else-if="componentName === 'video'" />
-    <ButtonsSideIndex v-else-if="componentName === 'buttons'" />
-    <div v-else class="fit column items-center justify-center">
-      <q-icon name="error" size="48px" color="negative" />
-      <div class="text-body1 q-mt-md">{{ $t('observation.popupComponentNotFound') }}</div>
-    </div>
+    <template v-else>
+      <VideoPlayer v-if="componentName === 'video'" />
+      <ButtonsSideIndex v-else-if="componentName === 'buttons'" />
+      <div v-else class="fit column items-center justify-center">
+        <q-icon name="error" size="48px" color="negative" />
+        <div class="text-body1 q-mt-md">{{ $t('observation.popupComponentNotFound') }}</div>
+      </div>
+
+      <div
+        v-if="popoutComponent && !state.hydrated"
+        class="popup-hydration-overlay column items-center justify-center"
+      >
+        <q-spinner color="primary" size="40px" />
+        <div class="text-body2 q-mt-md text-grey-7">
+          {{ $t('observation.popupHydrating') || $t('observation.popupLoading') }}
+        </div>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -52,6 +64,7 @@ export default defineComponent({
 
     const state = reactive({
       loading: false,
+      hydrated: false,
       error: '' as string,
     });
 
@@ -62,7 +75,16 @@ export default defineComponent({
         : null;
 
     let heartbeatTimer: number | null = null;
+    let hydrationTimeout: number | null = null;
     let lifecycleSignaled = false;
+    const unsubscribers: Array<() => void> = [];
+
+    const clearHydrationTimeout = () => {
+      if (hydrationTimeout !== null) {
+        clearTimeout(hydrationTimeout);
+        hydrationTimeout = null;
+      }
+    };
 
     // Signale la fermeture de la fenêtre pop-out pour réintégrer le panneau
     // dans la fenêtre principale (appelé sur unmount ET beforeunload).
@@ -73,6 +95,7 @@ export default defineComponent({
         clearInterval(heartbeatTimer);
         heartbeatTimer = null;
       }
+      clearHydrationTimeout();
       popout.markClosed(popoutComponent);
     };
 
@@ -93,6 +116,21 @@ export default defineComponent({
 
       windowSync.setObservationId(id);
 
+      unsubscribers.push(
+        windowSync.on('hydrate:complete', () => {
+          state.hydrated = true;
+          clearHydrationTimeout();
+        })
+      );
+
+      unsubscribers.push(
+        windowSync.on('popout:close-requested', (payload: { component?: unknown }) => {
+          if (!popoutComponent || payload?.component !== popoutComponent) return;
+          signalClosed();
+          window.close();
+        })
+      );
+
       state.loading = true;
       try {
         await observation.methods.loadObservation(id);
@@ -109,7 +147,17 @@ export default defineComponent({
         }
 
         // Demander l'état "vivant" à l'owner (relevés non encore persistés, etc.).
-        windowSync.broadcast('hydrate:request');
+        // Tant que `hydrate:complete` n'est pas reçu, l'overlay empêche les clics
+        // précoces de créer un état local non diffusé ou écrasé par l'hydratation.
+        if (popoutComponent) {
+          windowSync.broadcast('hydrate:request');
+          hydrationTimeout = window.setTimeout(() => {
+            state.hydrated = true;
+            hydrationTimeout = null;
+          }, 3000);
+        } else {
+          state.hydrated = true;
+        }
       } catch (error) {
         console.error('Erreur lors du chargement de la chronique:', error);
         state.error = t('observation.popupChronicleLoadError');
@@ -120,13 +168,27 @@ export default defineComponent({
 
     onUnmounted(() => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
+      unsubscribers.forEach((unsubscribe) => unsubscribe());
+      clearHydrationTimeout();
       signalClosed();
     });
 
     return {
       componentName,
+      popoutComponent,
       state,
     };
   },
 });
 </script>
+
+<style scoped>
+.popup-hydration-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(252, 252, 252, 0.85);
+  backdrop-filter: blur(1px);
+  pointer-events: all;
+}
+</style>

--- a/front/src/pages/userspace/observation/PopupView.vue
+++ b/front/src/pages/userspace/observation/PopupView.vue
@@ -22,7 +22,7 @@
       >
         <q-spinner color="primary" size="40px" />
         <div class="text-body2 q-mt-md text-grey-7">
-          {{ $t('observation.popupHydrating') || $t('observation.popupLoading') }}
+          {{ $t('observation.popupLoading') }}
         </div>
       </div>
     </template>


### PR DESCRIPTION
## Contexte

La désincrustation vidéo / boutons existe déjà et repose sur plusieurs fenêtres synchronisées via `BroadcastChannel`.

En relisant le flux, plusieurs cas fragiles ressortaient :

- une pop-up pouvait devenir interactive avant d'avoir reçu l'état vivant de la fenêtre principale
- la fenêtre principale ne pouvait fermer proprement une pop-up que si elle avait encore la référence `Window`
- les métadonnées de l'observation (`name`, `description`, `videoPath`, `mode`) n'étaient pas synchronisées entre fenêtres
- le bus inter-fenêtres ne distinguait pas explicitement la fin d'hydratation d'une simple demande d'état
- `updateObservation()` rechargeait toute l'observation, ce qui pouvait rediffuser des relevés persistés plus vieux que l'état vivant en mémoire

## Changements

### 1. Hydratation explicite des pop-ups

Ajout du message `hydrate:complete` dans `use-window-sync`.

La pop-up garde maintenant un overlay bloquant tant que l'owner n'a pas répondu à l'hydratation. Cela évite les clics trop précoces qui pourraient créer un état local non diffusé ou ensuite écrasé par l'état vivant de la fenêtre principale.

Un fallback de 3 secondes garde le comportement robuste si le message est perdu ou si la fenêtre principale n'est plus disponible.

### 2. Fermeture distante des pop-ups

Ajout du message `popout:close-requested` et de `popout.requestClose(component)`.

La fenêtre principale l'utilise lors de la réintégration d'un panneau. Cela couvre le cas où elle a perdu la référence JS directe vers la pop-up, par exemple après refresh/reload.

### 3. Synchronisation des métadonnées d'observation

Ajout de `state:observation-meta` dans `useObservation` pour propager :

- `name`
- `description`
- `videoPath`
- `mode`

Cela évite qu'une fenêtre reste sur un `videoPath` ou un mode obsolète lorsqu'une autre fenêtre met à jour l'observation.

Les followers ne diffusent ces métadonnées qu'après hydratation, pour éviter qu'un chargement initial en pop-up ne réécrase l'état de l'owner.

### 4. Mise à jour de métadonnées sans reload complet

`updateObservation()` applique maintenant les métadonnées renvoyées par l'API sur `currentObservation`, puis diffuse `state:observation-meta`, sans recharger les relevés et le protocole si l'observation courante est déjà chargée.

Cela évite qu'une pop-up hydratée recharge des relevés persistés et les rediffuse au-dessus d'un état vivant plus récent.

### 5. Nettoyage de la page Observation

Refactor léger de l'ouverture des pop-ups dans `Index.vue` :

- factorisation de l'ouverture `video` / `buttons`
- usage de `PopoutComponent`
- appel systématique de `requestClose()` lors d'une réintégration

## Validation attendue

Je n'ai pas exécuté l'application localement depuis cet environnement. À valider manuellement dans l'app Electron :

1. ouvrir une observation avec vidéo
2. désincruster la vidéo
3. désincruster les boutons
4. vérifier que la pop-up affiche brièvement l'overlay de chargement/hydratation
5. lancer la vidéo depuis la fenêtre vidéo
6. cliquer sur des boutons dans la fenêtre boutons
7. vérifier que les relevés apparaissent dans la fenêtre principale
8. fermer brutalement une pop-up et vérifier la réintégration après heartbeat
9. cliquer sur “réintégrer” depuis la fenêtre principale et vérifier que la pop-up se ferme aussi
10. modifier la vidéo ou le mode depuis une fenêtre et vérifier que l'autre fenêtre se met à jour
11. modifier une métadonnée d'observation et vérifier que les relevés vivants ne sont pas remplacés par un reload backend

## Fichiers modifiés

- `front/src/composables/use-window-sync/index.ts`
- `front/src/composables/use-popout/index.ts`
- `front/src/composables/use-observation/index.ts`
- `front/src/pages/userspace/observation/Index.vue`
- `front/src/pages/userspace/observation/PopupView.vue`