### PR TITLE
fix(pages): retrait des items 7 et 7bis du chapitre II

### DIFF
--- a/docs/github-pages/guide-test-beta.html
+++ b/docs/github-pages/guide-test-beta.html
@@ -427,12 +427,7 @@ const CHAPTERS = [
       "Testez les deux façons de saisir un observable dans la liste : via le menu déroulant (catégories en couleur, observables en noir), et en le tapant directement au clavier.",
       "Insérez aussi une ligne de commentaire (# texte) et vérifiez la saisie directement dans le tableau (sans fenêtre modale).",
       "Vérifiez la lisibilité de la police et le signalement en rouge des « Observable non reconnu »."]},
-    {num:"7", titre:"Indicateur de synchronisation", type:"guide", duree:"5 mn", desc:[
-      "Après avoir effectué des relevés et éditions, vérifiez s'il existe un indicateur visuel de synchronisation (relevés en cours de sauvegarde vs synchronisés).",
-      "Attendez quelques secondes et vérifiez que l'indicateur passe bien à « synchronisé »."]},
-    {num:"7bis", titre:"Annuler (CTRL+Z) (bonus)", type:"bonus", duree:"3 mn", desc:[
-      "Si disponible, testez l'annulation d'une action via CTRL+Z."]},
-    {num:"8", titre:"Autres tests", type:"libre", duree:"", desc:[]}
+    {num:"7", titre:"Autres tests", type:"libre", duree:"", desc:[]}
   ]
 },
 {


### PR DESCRIPTION
Suppression des tests 7 (Indicateur de synchronisation) et 7bis (Annuler CTRL+Z) du Chapitre II. Le dernier item du chapitre ("Autres tests", libre) est renumeroté de 8 à 7 pour rester cohérent.