### PR TITLE
Clarify observable entry instructions in guide

### DIFF
--- a/docs/github-pages/guide-test-beta.html
+++ b/docs/github-pages/guide-test-beta.html
@@ -424,7 +424,7 @@ const CHAPTERS = [
       "Sur la liste de relevés horodatés obtenue, testez : ajout d'une ligne par duplication, reclassement par horaire, suppression d'une ligne ou tout effacer.",
       "Testez Rechercher/Remplacer, modification de l'horodatage dans la grille (avec aide de format), et copier-coller d'un champ vers d'autres lignes."]},
     {num:"6", titre:"Saisie/modification d'un observable dans la liste", type:"scenario", duree:"10 mn", desc:[
-      "Testez les deux façons de saisir un observable dans la liste : via le menu déroulant (catégories en couleur, observables en noir), et en le tapant directement au clavier.",
+      "Testez les deux façons de saisir un observable dans la liste : via le menu déroulant (choisir dans la liste des observables qui apparaît), et en le tapant directement au clavier.",
       "Insérez aussi une ligne de commentaire (# texte) et vérifiez la saisie directement dans le tableau (sans fenêtre modale).",
       "Vérifiez la lisibilité de la police et le signalement en rouge des « Observable non reconnu »."]},
     {num:"7", titre:"Autres tests", type:"libre", duree:"", desc:[]}


### PR DESCRIPTION
Updated the description for entering observables in the list to clarify the dropdown selection process : la formule jugée pas claire par un utilisateur (catégories en couleur, observables en noir) est remplacée par  (choisir dans la liste des observables qui apparaît)