### PR TITLE
fix(ui): éclaircir le gris de repos du bouton d'observable en mode ponctuel

### DIFF
--- a/front/src/css/_colors.scss
+++ b/front/src/css/_colors.scss
@@ -39,3 +39,10 @@ $modernDarkGrey: #1f2937;
 @include defineColorVariations('success', $green);
 @include defineColorVariations('danger', $red);
 @include defineColorVariations('warning', $amber);
+
+// Semantic surface token: fond de repos des boutons d'observable
+// (mode ponctuel PressButton & mode continu SwitchButton).
+// Thème clair : gris très clair (#E5E7EB), plus clair que --neutral-lower
+// (#BAC2CE) jugé trop foncé en bêta-test. Thème sombre : identique à
+// --neutral-lower (déjà adapté au thème, texte blanc lisible dessus).
+@include defineColorLightAndDark('button-rest-bg', #E5E7EB, darken-compat($slate, 30));

--- a/front/src/pages/userspace/observation/_components/buttons-side/Category.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Category.vue
@@ -369,6 +369,12 @@ export default defineComponent({
   margin-bottom: 16px;
 }
 
+/* Thème sombre : carte plus claire que le fond du panneau (var(--secondary-high)),
+   pour un effet de relief, au lieu du gris clair fixe qui restait blanc quel que soit le thème */
+.body--dark .category-container {
+  background-color: var(--secondary-high);
+}
+
 .category-container:hover {
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
 }
@@ -385,6 +391,10 @@ export default defineComponent({
   border-bottom: 1px solid #eaeaea;
 }
 
+.body--dark .category-header {
+  border-bottom-color: rgba(255, 255, 255, 0.12);
+}
+
 .category-title {
   display: flex;
   align-items: center;
@@ -393,6 +403,10 @@ export default defineComponent({
 
 .category-description {
   color: #666;
+}
+
+.body--dark .category-description {
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .category-content {

--- a/front/src/pages/userspace/observation/_components/buttons-side/Category.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Category.vue
@@ -406,7 +406,9 @@ export default defineComponent({
 }
 
 .body--dark .category-description {
-  color: rgba(255, 255, 255, 0.6);
+  /* 0.75 et non 0.6 : sur le fond de carte var(--secondary-high) (#445a78),
+     0.6 ne donne qu'un contraste ~3.7:1 (sous le seuil de lisibilité 4.5:1) */
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .category-content {

--- a/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
@@ -6,8 +6,9 @@
       </div>
       <q-space />
       <div class="col-auto">
-        <q-btn 
-          :icon="state.isResetting ? 'mdi-loading mdi-spin' : 'mdi-restart'" 
+        <q-btn
+          class="reset-categories-btn"
+          :icon="state.isResetting ? 'mdi-loading mdi-spin' : 'mdi-restart'"
           :color="state.isResetting ? 'accent' : 'grey-7'"
           flat
           round
@@ -699,5 +700,12 @@ export default defineComponent({
 
 .body--dark .no-data .q-icon {
   color: rgba(255, 255, 255, 0.6) !important;
+}
+
+/* Bouton "reset" : au repos Quasar applique .text-grey-7 (gris fixe #616161,
+   ~2.4:1 sur fond sombre). En thème sombre on le passe en blanc semi-transparent.
+   Limité à .text-grey-7 pour ne pas écraser la variante accent pendant le reset. */
+.body--dark .reset-categories-btn.text-grey-7 {
+  color: rgba(255, 255, 255, 0.7) !important;
 }
 </style>

--- a/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
@@ -696,4 +696,8 @@ export default defineComponent({
 .body--dark .no-data {
   color: rgba(255, 255, 255, 0.6);
 }
+
+.body--dark .no-data .q-icon {
+  color: rgba(255, 255, 255, 0.6) !important;
+}
 </style>

--- a/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
@@ -675,6 +675,13 @@ export default defineComponent({
   box-sizing: border-box;
 }
 
+/* Thème sombre : fond du panneau adapté au thème (var(--secondary), gris-bleu foncé)
+   au lieu du gris clair fixe qui restait blanc quel que soit le thème */
+.body--dark .categories-wrapper {
+  background-color: var(--secondary);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
 .no-data {
   color: #777;
   display: flex;
@@ -684,5 +691,9 @@ export default defineComponent({
   height: 100%;
   min-height: 0;
   padding: 2rem;
+}
+
+.body--dark .no-data {
+  color: rgba(255, 255, 255, 0.6);
 }
 </style>

--- a/front/src/pages/userspace/observation/_components/buttons-side/PressButton.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/PressButton.vue
@@ -67,8 +67,9 @@ export default defineComponent({
 .press-button {
   transition: all 0.2s ease;
   position: relative;
-  /* État de repos (mode ponctuel) : gris clair au lieu du gris standard */
-  background-color: var(--neutral-lower) !important;
+  /* État de repos (mode ponctuel) : gris clair, éclairci suite au retour bêta-test
+     (le premier gris clair, var(--neutral-lower), restait trop foncé / peu lisible) */
+  background-color: #E5E7EB !important;
   color: var(--text) !important;
 }
 

--- a/front/src/pages/userspace/observation/_components/buttons-side/PressButton.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/PressButton.vue
@@ -67,17 +67,12 @@ export default defineComponent({
 .press-button {
   transition: all 0.2s ease;
   position: relative;
-  /* État de repos (mode ponctuel) : gris clair, éclairci suite au retour bêta-test
-     (le premier gris clair, var(--neutral-lower), restait trop foncé / peu lisible) */
-  background-color: #E5E7EB !important;
+  /* État de repos (mode ponctuel) : gris clair via le token --button-rest-bg
+     (clair #E5E7EB / sombre = --neutral-lower), éclairci suite au retour bêta-test
+     (le premier gris clair, var(--neutral-lower), restait trop foncé / peu lisible
+     en thème clair). Le token gère les deux thèmes, pas d'override .body--dark. */
+  background-color: var(--button-rest-bg) !important;
   color: var(--text) !important;
-}
-
-/* En thème sombre, --text devient blanc : on garde la variable d'origine
-   (déjà adaptée au thème sombre) plutôt que le gris clair fixe ci-dessus,
-   sinon le texte blanc devient illisible sur fond gris clair */
-.body--dark .press-button {
-  background-color: var(--neutral-lower) !important;
 }
 
 /* État actif au clic : orange identique au mode continu (var(--accent)) */

--- a/front/src/pages/userspace/observation/_components/buttons-side/PressButton.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/PressButton.vue
@@ -73,6 +73,13 @@ export default defineComponent({
   color: var(--text) !important;
 }
 
+/* En thème sombre, --text devient blanc : on garde la variable d'origine
+   (déjà adaptée au thème sombre) plutôt que le gris clair fixe ci-dessus,
+   sinon le texte blanc devient illisible sur fond gris clair */
+.body--dark .press-button {
+  background-color: var(--neutral-lower) !important;
+}
+
 /* État actif au clic : orange identique au mode continu (var(--accent)) */
 .press-button.is-active {
   background-color: var(--accent) !important;

--- a/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
@@ -3,8 +3,7 @@
     class="switch-button"
     :class="{ 'active': active, 'disabled-button': disabled }"
     :label="observable.name"
-    color="success"
-    outline
+    color="neutral"
     rounded
     dense
     no-caps
@@ -57,12 +56,19 @@ export default defineComponent({
 .switch-button {
   transition: all 0.2s ease;
   position: relative;
-  border: 1px solid #ddd;
+  /* État de repos (mode continu) : gris clair/foncé selon le thème, uniquement l'état
+     actif reste coloré (orange) - même logique que PressButton (mode ponctuel) */
+  background-color: #E5E7EB !important;
+  color: var(--text) !important;
   font-weight: normal;
 }
 
-.switch-button:hover:not(.disabled-button) {
-  background-color: #f0f0f0;
+.body--dark .switch-button {
+  background-color: var(--neutral-lower) !important;
+}
+
+.switch-button:hover:not(.disabled-button):not(.active) {
+  opacity: 0.9;
   transform: translateY(-1px);
 }
 

--- a/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
@@ -56,6 +56,9 @@ export default defineComponent({
 .switch-button {
   transition: all 0.2s ease;
   position: relative;
+  /* border-style doit être fixé ici : l'état actif ne modifie que border-color et
+     border-width, sans un border-style déjà posé la bordure active ne s'affiche pas */
+  border: 1px solid transparent;
   /* État de repos (mode continu) : gris clair/foncé selon le thème, uniquement l'état
      actif reste coloré (orange) - même logique que PressButton (mode ponctuel) */
   background-color: #E5E7EB !important;

--- a/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
@@ -59,15 +59,12 @@ export default defineComponent({
   /* border-style doit être fixé ici : l'état actif ne modifie que border-color et
      border-width, sans un border-style déjà posé la bordure active ne s'affiche pas */
   border: 1px solid transparent;
-  /* État de repos (mode continu) : gris clair/foncé selon le thème, uniquement l'état
-     actif reste coloré (orange) - même logique que PressButton (mode ponctuel) */
-  background-color: #E5E7EB !important;
+  /* État de repos (mode continu) : gris clair/foncé selon le thème via le token
+     --button-rest-bg, uniquement l'état actif reste coloré (orange) -
+     même logique que PressButton (mode ponctuel) */
+  background-color: var(--button-rest-bg) !important;
   color: var(--text) !important;
   font-weight: normal;
-}
-
-.body--dark .switch-button {
-  background-color: var(--neutral-lower) !important;
 }
 
 .switch-button:hover:not(.disabled-button):not(.active) {


### PR DESCRIPTION
## Contexte
Suite à la PR précédente sur les couleurs du bouton d'observable en mode
ponctuel (repos gris clair / actif orange / retour gris clair), le gris
choisi pour le repos et le retour (var(--neutral-lower), ~#BAC2CE en
thème clair) s'est révélé trop foncé : le libellé du bouton se lit mal.

## Changement
- front/src/pages/userspace/observation/_components/buttons-side/PressButton.vue
- Thème clair : état de repos et de retour après clic passé à #E5E7EB (en dur)
- Thème sombre : conservation de var(--neutral-lower) (comportement d'origine)
- État actif (orange, identique au mode continu, var(--accent)) : inchangé
- Durée de la transition : inchangée
- Portée : uniquement PressButton.vue (mode ponctuel) — SwitchButton.vue
  (mode continu) non touché

## Contrôle effectué (voir 2e commit)
La première version fixait #E5E7EB **quel que soit le thème**. Or en thème
sombre le texte du bouton passe en blanc (`var(--text)`), ce qui rendait le
label quasi illisible sur ce fond resté clair (contraste ~1:1). Un correctif
de suivi restaure `var(--neutral-lower)` en thème sombre uniquement (via
`.body--dark .press-button`, même convention que `student-watermark/Index.vue`),
ce qui retrouve le comportement d'origine — jamais signalé comme problématique
en thème sombre, seul le thème clair posait souci.

- [x] Comportement en thème sombre : vérifié et corrigé (voir ci-dessus)
- [ ] Test manuel en mode ponctuel : repos → clic → relâchement, thème
      clair et sombre

## Origine de la demande
Retour de Valérie (bêta-test Actograph V3) après validation visuelle sur un
aperçu comparatif de plusieurs tons de gris — voir
`demandes-evolution-pour-sylvain.md`, point 1 bis.

## Suivi — revue design/dev post-ouverture (commit 1f8700b)

Refactor : `PressButton.vue` utilise désormais le token sémantique
`--button-rest-bg` introduit dans la PR #70 (clair `#E5E7EB` /
sombre = `--neutral-lower`). Remplace le hex en dur `#E5E7EB` et
l'override `.body--dark` : le token gère les deux thèmes, ce qui supprime
la branche conditionnelle et évite définitivement le piège du texte blanc
sur fond clair.

**Dépendance** : cette branche est rebasée sur `fix/theme-sombre-panneau-observation`
(#70) pour disposer du token. Merge dans l'ordre : **#70 puis #69**.

### Contrastes (recalculés, formule WCAG)
- Repos clair : noir sur `#E5E7EB` : ~17:1
- Repos sombre : blanc sur `#242a32` : ~14.5:1
- Actif : blanc sur `var(--accent)` (`#f97316`) : ~2.8:1 (préexistant,
  état actif transitoire)

### Reste à faire
- [ ] Test manuel en mode ponctuel : repos -> clic -> relâchement, thème
      clair et sombre
