### PR TITLE
fix(ui): adapter le panneau d'observation au thème sombre

### DIFF
--- a/front/src/css/_colors.scss
+++ b/front/src/css/_colors.scss
@@ -39,3 +39,10 @@ $modernDarkGrey: #1f2937;
 @include defineColorVariations('success', $green);
 @include defineColorVariations('danger', $red);
 @include defineColorVariations('warning', $amber);
+
+// Semantic surface token: fond de repos des boutons d'observable
+// (mode ponctuel PressButton & mode continu SwitchButton).
+// Thème clair : gris très clair (#E5E7EB), plus clair que --neutral-lower
+// (#BAC2CE) jugé trop foncé en bêta-test. Thème sombre : identique à
+// --neutral-lower (déjà adapté au thème, texte blanc lisible dessus).
+@include defineColorLightAndDark('button-rest-bg', #E5E7EB, darken-compat($slate, 30));

--- a/front/src/pages/userspace/observation/_components/buttons-side/Category.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Category.vue
@@ -369,6 +369,12 @@ export default defineComponent({
   margin-bottom: 16px;
 }
 
+/* Thème sombre : carte plus claire que le fond du panneau (var(--secondary-high)),
+   pour un effet de relief, au lieu du gris clair fixe qui restait blanc quel que soit le thème */
+.body--dark .category-container {
+  background-color: var(--secondary-high);
+}
+
 .category-container:hover {
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
 }
@@ -385,6 +391,10 @@ export default defineComponent({
   border-bottom: 1px solid #eaeaea;
 }
 
+.body--dark .category-header {
+  border-bottom-color: rgba(255, 255, 255, 0.12);
+}
+
 .category-title {
   display: flex;
   align-items: center;
@@ -393,6 +403,10 @@ export default defineComponent({
 
 .category-description {
   color: #666;
+}
+
+.body--dark .category-description {
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .category-content {

--- a/front/src/pages/userspace/observation/_components/buttons-side/Category.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Category.vue
@@ -406,7 +406,9 @@ export default defineComponent({
 }
 
 .body--dark .category-description {
-  color: rgba(255, 255, 255, 0.6);
+  /* 0.75 et non 0.6 : sur le fond de carte var(--secondary-high) (#445a78),
+     0.6 ne donne qu'un contraste ~3.7:1 (sous le seuil de lisibilité 4.5:1) */
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .category-content {

--- a/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
@@ -6,8 +6,9 @@
       </div>
       <q-space />
       <div class="col-auto">
-        <q-btn 
-          :icon="state.isResetting ? 'mdi-loading mdi-spin' : 'mdi-restart'" 
+        <q-btn
+          class="reset-categories-btn"
+          :icon="state.isResetting ? 'mdi-loading mdi-spin' : 'mdi-restart'"
           :color="state.isResetting ? 'accent' : 'grey-7'"
           flat
           round
@@ -699,5 +700,12 @@ export default defineComponent({
 
 .body--dark .no-data .q-icon {
   color: rgba(255, 255, 255, 0.6) !important;
+}
+
+/* Bouton "reset" : au repos Quasar applique .text-grey-7 (gris fixe #616161,
+   ~2.4:1 sur fond sombre). En thème sombre on le passe en blanc semi-transparent.
+   Limité à .text-grey-7 pour ne pas écraser la variante accent pendant le reset. */
+.body--dark .reset-categories-btn.text-grey-7 {
+  color: rgba(255, 255, 255, 0.7) !important;
 }
 </style>

--- a/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
@@ -696,4 +696,8 @@ export default defineComponent({
 .body--dark .no-data {
   color: rgba(255, 255, 255, 0.6);
 }
+
+.body--dark .no-data .q-icon {
+  color: rgba(255, 255, 255, 0.6) !important;
+}
 </style>

--- a/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
@@ -675,6 +675,13 @@ export default defineComponent({
   box-sizing: border-box;
 }
 
+/* Thème sombre : fond du panneau adapté au thème (var(--secondary), gris-bleu foncé)
+   au lieu du gris clair fixe qui restait blanc quel que soit le thème */
+.body--dark .categories-wrapper {
+  background-color: var(--secondary);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
 .no-data {
   color: #777;
   display: flex;
@@ -684,5 +691,9 @@ export default defineComponent({
   height: 100%;
   min-height: 0;
   padding: 2rem;
+}
+
+.body--dark .no-data {
+  color: rgba(255, 255, 255, 0.6);
 }
 </style>

--- a/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
@@ -3,8 +3,7 @@
     class="switch-button"
     :class="{ 'active': active, 'disabled-button': disabled }"
     :label="observable.name"
-    color="success"
-    outline
+    color="neutral"
     rounded
     dense
     no-caps
@@ -57,12 +56,19 @@ export default defineComponent({
 .switch-button {
   transition: all 0.2s ease;
   position: relative;
-  border: 1px solid #ddd;
+  /* État de repos (mode continu) : gris clair/foncé selon le thème, uniquement l'état
+     actif reste coloré (orange) - même logique que PressButton (mode ponctuel) */
+  background-color: #E5E7EB !important;
+  color: var(--text) !important;
   font-weight: normal;
 }
 
-.switch-button:hover:not(.disabled-button) {
-  background-color: #f0f0f0;
+.body--dark .switch-button {
+  background-color: var(--neutral-lower) !important;
+}
+
+.switch-button:hover:not(.disabled-button):not(.active) {
+  opacity: 0.9;
   transform: translateY(-1px);
 }
 

--- a/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
@@ -56,6 +56,9 @@ export default defineComponent({
 .switch-button {
   transition: all 0.2s ease;
   position: relative;
+  /* border-style doit être fixé ici : l'état actif ne modifie que border-color et
+     border-width, sans un border-style déjà posé la bordure active ne s'affiche pas */
+  border: 1px solid transparent;
   /* État de repos (mode continu) : gris clair/foncé selon le thème, uniquement l'état
      actif reste coloré (orange) - même logique que PressButton (mode ponctuel) */
   background-color: #E5E7EB !important;

--- a/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/SwitchButton.vue
@@ -59,15 +59,12 @@ export default defineComponent({
   /* border-style doit être fixé ici : l'état actif ne modifie que border-color et
      border-width, sans un border-style déjà posé la bordure active ne s'affiche pas */
   border: 1px solid transparent;
-  /* État de repos (mode continu) : gris clair/foncé selon le thème, uniquement l'état
-     actif reste coloré (orange) - même logique que PressButton (mode ponctuel) */
-  background-color: #E5E7EB !important;
+  /* État de repos (mode continu) : gris clair/foncé selon le thème via le token
+     --button-rest-bg, uniquement l'état actif reste coloré (orange) -
+     même logique que PressButton (mode ponctuel) */
+  background-color: var(--button-rest-bg) !important;
   color: var(--text) !important;
   font-weight: normal;
-}
-
-.body--dark .switch-button {
-  background-color: var(--neutral-lower) !important;
 }
 
 .switch-button:hover:not(.disabled-button):not(.active) {


### PR DESCRIPTION
## Contexte
En thème sombre, le panneau "Tableau de bord d'observation" (cartes
Lieu/Action + fond derrière) restait entièrement clair alors que le reste
de l'interface (barre latérale, barre de titre) passait bien en sombre.
Capture d'écran fournie par Valérie (bêta-test) montrant le problème.

## Cause
Deux fichiers fixaient leur couleur de fond en dur, sans passer par le
système de variables de couleurs adaptées au thème déjà utilisé ailleurs
dans l'appli :
- `Index.vue` (buttons-side) : `.categories-wrapper` en `#fcfcfc`
- `Category.vue` : `.category-container` en `#f9f9f9`

## Changement
- Thème sombre : fond du panneau → `var(--secondary)` (#1f2937, gris-bleu
  foncé, volontairement pas de noir pur)
- Thème sombre : fond des cartes Lieu/Action → `var(--secondary-high)`
  (#445a78), plus clair que le fond du panneau (effet de relief)
- Bordure de titre + texte de description des cartes : blanc semi-
  transparent en thème sombre (restaient en gris clair fixe, peu lisibles)
- Bonus (même retour visuel) : boutons du mode continu (SwitchButton.vue)
  alignés sur la même logique que PressButton.vue (mode ponctuel) : gris
  clair/foncé au repos, orange uniquement à l'état actif, au lieu du vert
  fixe précédent — thème clair non touché

## Revue technique effectuée (2e commit)
Une relecture a posteriori du 1er commit a permis de corriger 2 régressions
introduites par erreur, avant tout retour de Sylvain :

1. **Bordure active invisible** : en supprimant l'ancienne bordure fixe de
   `SwitchButton.vue` (`border: 1px solid #ddd`), le `border-style` du
   bouton n'était plus défini nulle part. Or l'état actif ne modifie que
   `border-color`/`border-width`, pas le style — sans style déjà posé,
   la bordure orange de l'état actif ne s'affichait plus du tout.
   Corrigé avec `border: 1px solid transparent` au repos.
2. **Contraste insuffisant** : le texte de description en thème sombre
   (`rgba(255,255,255,0.6)`) ne donnait qu'un contraste ~3.7:1 sur le
   nouveau fond de carte `#445a78` (calcul WCAG), sous le seuil de
   lisibilité recommandé de 4.5:1. Opacité remontée à 0.75 (~4.8:1).
3. Bonus : l'icône "info" de l'écran vide (aucun protocole chargé)
   utilisait un gris Quasar fixe (`grey-7`), non adapté au thème sombre
   (contraste ~2.4:1 sur le nouveau fond) — corrigée également.

Contrastes vérifiés par calcul (formule de luminance relative WCAG), pas
à l'œil :
- Texte blanc sur `--secondary` (#1f2937) : ~14.7:1
- Texte blanc sur `--secondary-high` (#445a78) : ~7.1:1
- Description (opacité 0.75) sur `--secondary-high` : ~4.8:1
- Texte blanc sur `var(--neutral-lower)` sombre (boutons au repos) : ~14.5:1

## Portée vérifiée
- Thème clair : aucun changement (couleurs fixes conservées telles quelles).
- Uniquement 3 fichiers du panneau d'observation, pas d'impact sur les
  autres pages.
- Vérifié qu'il existe une définition `--secondary` inutilisée et non
  importée dans `lib-improba/css/_colors.scss` (violette, différente) :
  confirmé qu'elle n'est chargée nulle part dans le build, donc pas de
  conflit avec la valeur réellement utilisée (`src/css/_colors.scss`).

## Non testé visuellement dans l'appli
Correction basée sur la lecture du système de variables de couleurs et sur
un calcul de contraste WCAG, pas sur un build Electron lancé depuis cette
session (dépendances non installées). À confirmer à l'écran avant merge.

## Origine de la demande
Retour de Valérie (bêta-test Actograph V3) sur une capture d'écran du
panneau d'observation en thème sombre.

## Suivi — revue design/dev post-ouverture (commit 3d6badc)

Revue effectuée avec un oeil design (contraste WCAG, cohérence thème
clair/sombre) et un oeil dev expert. Corrections poussées sur cette branche :

1. **Bouton « reset » du panneau (Index.vue)** : au repos il restait en
   `.text-grey-7` Quasar (`#616161`, ~2.4:1 sur fond sombre), même souci
   que l'icône info déjà corrigée mais oublié ici. Override
   `.body--dark .reset-categories-btn.text-grey-7` -> blanc semi-transparent
   (~0.7), limité à `.text-grey-7` pour ne pas écraser la variante `accent`
   pendant le reset.

2. **Token sémantique `--button-rest-bg`** dans `_colors.scss`
   (clair `#E5E7EB` / sombre = `--neutral-lower`). Remplace le hex en dur
   `#E5E7EB` dans `SwitchButton.vue` et supprime l'override `.body--dark`
   redondant (le token gère les deux thèmes). `PressButton.vue` (#69) utilise
   le même token.

### Clarification de scope (SwitchButton)
Le bonus « alignement du mode continu sur le mode ponctuel » modifie
**aussi le thème clair** : le bouton passe de `color="success" outline`
(vert contour) à fond gris rempli (`--button-rest-bg`) avec orange à
l'état actif. Ce n'est donc pas strictement « thème clair non touché »
comme écrit plus haut. Changement volontaire (alignement PressButton /
SwitchButton), à confirmer à l'écran avant merge.

### Contrastes (recalculés, formule WCAG)
- Description carte `rgba(255,255,255,0.75)` sur `#445a78` : 4.8:1 (AA ok)
- Blanc sur `#1f2937` : 14.7:1 / sur `#445a78` : 7.1:1
- Bouton repos clair : noir sur `#E5E7EB` : ~17:1
- Bouton repos sombre : blanc sur `#242a32` : ~14.5:1

### Reste à faire
- [ ] Test manuel visuel dans Electron (build non lancé)
- [ ] merger #70 avant #69 (la #69 est rebasée sur cette branche)
