### PR TITLE
feat(statistics): export PNG/JPEG des graphiques (camembert + histogramme)

### DIFF
--- a/front/src/composables/use-chart-image-export.ts
+++ b/front/src/composables/use-chart-image-export.ts
@@ -1,0 +1,52 @@
+import { reactive } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useQuasar } from 'quasar';
+import type { Exporting } from '@amcharts/amcharts5/plugins/exporting';
+
+export type ChartImageExportFormat = 'png' | 'jpg';
+
+/**
+ * Export PNG/JPEG d'un graphique amCharts5, avec le même menu que celui du
+ * graphe d'activité (bouton "Exporter" + sélecteur de format).
+ */
+export const useChartImageExport = (getExporting: () => Exporting | null) => {
+  const { t } = useI18n();
+  const $q = useQuasar();
+
+  const exportSelection = reactive<{ format: ChartImageExportFormat }>({
+    format: 'png',
+  });
+
+  const exportFormatOptions: Array<{ label: string; value: ChartImageExportFormat }> = [
+    { label: 'PNG', value: 'png' },
+    { label: 'JPEG', value: 'jpg' },
+  ];
+
+  const runExport = async () => {
+    const exporting = getExporting();
+    if (!exporting) {
+      $q.notify({ type: 'warning', message: t('graphUi.exportNotReady') });
+      return;
+    }
+
+    try {
+      await exporting.download(exportSelection.format);
+      $q.notify({
+        type: 'positive',
+        message: t('graphUi.exportedFormat', {
+          what: t('graphUi.exportContentGraph'),
+          format: exportSelection.format.toUpperCase(),
+        }),
+        timeout: 3000,
+      });
+    } catch (error) {
+      console.error('Failed to export chart image:', error);
+    }
+  };
+
+  return {
+    exportSelection,
+    exportFormatOptions,
+    runExport,
+  };
+};

--- a/front/src/pages/userspace/statistics/_components/AmChartsBarChart.vue
+++ b/front/src/pages/userspace/statistics/_components/AmChartsBarChart.vue
@@ -1,14 +1,56 @@
 <template>
-  <div ref="chartContainer" :style="{ width: '100%', height: height + 'px' }"></div>
+  <div class="relative-position" :style="{ width: '100%', height: height + 'px' }">
+    <div ref="chartContainer" class="fit"></div>
+    <q-btn
+      flat
+      round
+      dense
+      color="grey-8"
+      icon="mdi-download"
+      class="absolute chart-export-btn"
+    >
+      <q-tooltip>{{ t('graphUi.exportMenuLabel') }}</q-tooltip>
+      <q-menu anchor="bottom right" self="top right" :offset="[0, 8]">
+        <div class="q-pa-md" style="min-width: 220px">
+          <div class="text-weight-medium q-mb-sm">{{ t('graphUi.exportSectionFormat') }}</div>
+          <div class="row q-gutter-sm q-mb-md">
+            <q-btn
+              v-for="opt in exportFormatOptions"
+              :key="opt.value"
+              :label="opt.label"
+              :color="exportSelection.format === opt.value ? 'primary' : 'grey-3'"
+              :text-color="exportSelection.format === opt.value ? 'white' : 'grey-9'"
+              no-caps
+              unelevated
+              class="col"
+              @click="exportSelection.format = opt.value"
+            />
+          </div>
+          <q-btn
+            color="primary"
+            no-caps
+            unelevated
+            icon="mdi-download"
+            :label="t('graphUi.exportAction')"
+            class="full-width"
+            v-close-popup
+            @click="runExport"
+          />
+        </div>
+      </q-menu>
+    </q-btn>
+  </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, ref, onMounted, onUnmounted, watch, PropType } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useAppResume, onChartsRefresh } from 'src/composables/use-app-resume';
+import { useChartImageExport } from 'src/composables/use-chart-image-export';
 import { isElementVisible } from 'src/utils/dom.utils';
 import * as am5 from '@amcharts/amcharts5';
 import * as am5xy from '@amcharts/amcharts5/xy';
+import * as am5exporting from '@amcharts/amcharts5/plugins/exporting';
 import am5themes_Animated from '@amcharts/amcharts5/themes/Animated';
 
 export default defineComponent({
@@ -36,6 +78,7 @@ export default defineComponent({
     const chartContainer = ref<HTMLElement | null>(null);
     let root: am5.Root | null = null;
     let chart: am5xy.XYChart | null = null;
+    let exporting: am5exporting.Exporting | null = null;
 
     const emptyRow = () => ({ label: '', value: 0 });
 
@@ -194,6 +237,10 @@ export default defineComponent({
           sprite: label,
         });
       });
+
+      exporting = am5exporting.Exporting.new(root, {
+        filePrefix: 'graphique-statistiques',
+      });
     };
 
     const updateChart = () => {
@@ -224,6 +271,10 @@ export default defineComponent({
       createChart();
     };
 
+    const { exportSelection, exportFormatOptions, runExport } = useChartImageExport(
+      () => exporting,
+    );
+
     let unsubscribeChartsRefresh: (() => void) | null = null;
 
     onMounted(() => {
@@ -239,6 +290,7 @@ export default defineComponent({
         root.dispose();
         root = null;
         chart = null;
+        exporting = null;
       }
     });
 
@@ -270,9 +322,21 @@ export default defineComponent({
     });
 
     return {
+      t,
       chartContainer,
+      exportSelection,
+      exportFormatOptions,
+      runExport,
     };
   },
 });
 </script>
+
+<style scoped lang="scss">
+.chart-export-btn {
+  top: 0;
+  right: 0;
+  z-index: 5;
+}
+</style>
 

--- a/front/src/pages/userspace/statistics/_components/AmChartsPieChart.vue
+++ b/front/src/pages/userspace/statistics/_components/AmChartsPieChart.vue
@@ -1,14 +1,56 @@
 <template>
-  <div ref="chartContainer" :style="{ width: '100%', height: height + 'px' }"></div>
+  <div class="relative-position" :style="{ width: '100%', height: height + 'px' }">
+    <div ref="chartContainer" class="fit"></div>
+    <q-btn
+      flat
+      round
+      dense
+      color="grey-8"
+      icon="mdi-download"
+      class="absolute chart-export-btn"
+    >
+      <q-tooltip>{{ t('graphUi.exportMenuLabel') }}</q-tooltip>
+      <q-menu anchor="bottom right" self="top right" :offset="[0, 8]">
+        <div class="q-pa-md" style="min-width: 220px">
+          <div class="text-weight-medium q-mb-sm">{{ t('graphUi.exportSectionFormat') }}</div>
+          <div class="row q-gutter-sm q-mb-md">
+            <q-btn
+              v-for="opt in exportFormatOptions"
+              :key="opt.value"
+              :label="opt.label"
+              :color="exportSelection.format === opt.value ? 'primary' : 'grey-3'"
+              :text-color="exportSelection.format === opt.value ? 'white' : 'grey-9'"
+              no-caps
+              unelevated
+              class="col"
+              @click="exportSelection.format = opt.value"
+            />
+          </div>
+          <q-btn
+            color="primary"
+            no-caps
+            unelevated
+            icon="mdi-download"
+            :label="t('graphUi.exportAction')"
+            class="full-width"
+            v-close-popup
+            @click="runExport"
+          />
+        </div>
+      </q-menu>
+    </q-btn>
+  </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, ref, onMounted, onUnmounted, watch, PropType } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useAppResume, onChartsRefresh } from 'src/composables/use-app-resume';
+import { useChartImageExport } from 'src/composables/use-chart-image-export';
 import { isElementVisible } from 'src/utils/dom.utils';
 import * as am5 from '@amcharts/amcharts5';
 import * as am5percent from '@amcharts/amcharts5/percent';
+import * as am5exporting from '@amcharts/amcharts5/plugins/exporting';
 import am5themes_Animated from '@amcharts/amcharts5/themes/Animated';
 
 export default defineComponent({
@@ -28,10 +70,11 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { locale } = useI18n();
+    const { t, locale } = useI18n();
     const chartContainer = ref<HTMLElement | null>(null);
     let root: am5.Root | null = null;
     let chart: am5percent.PieChart | null = null;
+    let exporting: am5exporting.Exporting | null = null;
 
     const emptySlice = () => ({ label: '', value: 1 });
 
@@ -103,6 +146,10 @@ export default defineComponent({
       );
 
       legend.data.setAll(series.dataItems);
+
+      exporting = am5exporting.Exporting.new(root, {
+        filePrefix: 'graphique-statistiques',
+      });
     };
 
     const updateChart = () => {
@@ -134,6 +181,10 @@ export default defineComponent({
       createChart();
     };
 
+    const { exportSelection, exportFormatOptions, runExport } = useChartImageExport(
+      () => exporting,
+    );
+
     let unsubscribeChartsRefresh: (() => void) | null = null;
 
     onMounted(() => {
@@ -149,6 +200,7 @@ export default defineComponent({
         root.dispose();
         root = null;
         chart = null;
+        exporting = null;
       }
     });
 
@@ -181,9 +233,21 @@ export default defineComponent({
     });
 
     return {
+      t,
       chartContainer,
+      exportSelection,
+      exportFormatOptions,
+      runExport,
     };
   },
 });
 </script>
+
+<style scoped lang="scss">
+.chart-export-btn {
+  top: 0;
+  right: 0;
+  z-index: 5;
+}
+</style>
 


### PR DESCRIPTION
## Résumé
- Ajoute un bouton d'export PNG/JPEG sur chaque graphique amCharts des statistiques (camembert `AmChartsPieChart.vue` et histogramme `AmChartsBarChart.vue`), positionné en haut à droite du graphique.
- Repris à l'identique du menu d'export du graphe d'activité (`graphUi.exportMenuLabel`, sélecteur de format, bouton d'action) pour rester cohérent avec le reste de l'app — aucune nouvelle clé de traduction nécessaire.
- Comme ces 2 composants sont réutilisés dans l'onglet **Par catégorie** (camembert + histogramme) et **Mode avancé** (camembert + histogramme), le bouton apparaît automatiquement aux 4 emplacements concernés sans duplication de code.
- Utilise le plugin `exporting` déjà fourni par `@amcharts/amcharts5` (aucune nouvelle dépendance).
- La logique de sélection de format + téléchargement est factorisée dans un nouveau composable `src/composables/use-chart-image-export.ts`, partagé par les deux composants de graphique.

## Test plan
- [x] `vue-tsc --noEmit` : aucune nouvelle erreur (les erreurs existantes sur `main` viennent des fichiers de test Jest, non liés à ce changement)
- [x] `eslint` sur les fichiers modifiés : propre
- [ ] Vérification manuelle dans l'app (onglets Par catégorie / Mode avancé, cliquer sur le bouton d'export de chaque graphique et vérifier le fichier téléchargé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)