### PR TITLE
fix(front): corriger l'interpolation des {name} dans les traductions (build production)

### DIFF
--- a/front/quasar.config.js
+++ b/front/quasar.config.js
@@ -112,9 +112,11 @@ module.exports = configure(function (/* ctx */) {
             // if you want to use Vue I18n Legacy API, you need to set `compositionOnly: false`
             // compositionOnly: false,
 
-            // if you want to use named tokens in your Vue I18n messages, such as 'Hello {name}',
-            // you need to set `runtimeOnly: false`
-            // runtimeOnly: false,
+            // Locale messages live in .ts files (src/i18n/**), which this plugin
+            // does not pre-compile (only .json/.yaml/.json5 are). Without the
+            // message compiler bundled, named tokens like 'Statistiques : {name}'
+            // are shown literally in production builds. Keep the full compiler.
+            runtimeOnly: false,
 
             // you need to set i18n resource including paths !
             include: path.resolve(__dirname, './src/i18n/**'),


### PR DESCRIPTION
## Contexte

Valérie a signalé que dans l'onglet **Statistiques > Par catégorie**, le titre au-dessus des graphiques affichait littéralement `Statistiques : {name}` au lieu du nom de la catégorie.

## Cause racine

Ce n'est pas une faute de frappe dans un texte : les fichiers de locale (`front/src/i18n/**`) sont des `.ts`, que le plugin `@intlify/vite-plugin-vue-i18n` ne pré-compile pas (seuls `.json`/`.yaml`/`.json5` le sont). L'option `runtimeOnly` était restée à sa valeur par défaut (`true`), ce qui fait que le build de production embarque la version *runtime-only* de vue-i18n, sans le compilateur de messages. Résultat : tous les jetons nommés type `{name}`, `{count}`, etc. ne sont jamais interpolés en production (ils fonctionnent en dev car le compilateur complet y est présent).

Le fichier `quasar.config.js` contenait déjà un commentaire documentant exactement ce point (`// si vous voulez utiliser des jetons nommés... vous devez mettre runtimeOnly: false`), mais ce n'était jamais activé.

## Correctif

Activation de `runtimeOnly: false` dans `front/quasar.config.js` pour le plugin `@intlify/vite-plugin-vue-i18n`, conformément à sa documentation.

## Impact

Corrige le cas signalé (titre des statistiques par catégorie) et, potentiellement, d'autres textes du même type ailleurs dans l'app qui n'avaient pas encore été remarqués (ex. confirmations de suppression "Voulez-vous supprimer « {name} » ?").

## Vérification

Je n'ai pas pu lancer un build de production complet dans cet environnement (le hook `beforeBuild` échoue pour une raison indépendante : le chemin du dossier de travail contient un espace). Un test de build + vérification visuelle de l'onglet Statistiques > Par catégorie côté Sylvain serait utile avant merge.

---
🤖 Rapporté par Valérie, corrigé via Claude Code.