### PR TITLE
fix(statistics): propager la couleur de catégorie/observable du Graph vers les diagrammes

### DIFF
--- a/api/src/core/observations/dtos/statistics-category.dto.ts
+++ b/api/src/core/observations/dtos/statistics-category.dto.ts
@@ -15,6 +15,9 @@ export class CategoryStatisticsDto {
 
   @Expose()
   totalCategoryDuration?: number; // Total duration of all observables in this category (milliseconds)
+
+  @Expose()
+  observationDuration?: number; // Full observation window (first START to last STOP) used as the percentage basis (milliseconds)
 }
 
 export class ObservableStatisticsDto {

--- a/front/src/composables/use-statistics/__tests__/category-pie-chart.utils.test.ts
+++ b/front/src/composables/use-statistics/__tests__/category-pie-chart.utils.test.ts
@@ -1,6 +1,7 @@
 import {
   buildCategoryPieChartData,
   buildCategoryPieChartColors,
+  calculateUnaccountedPieDuration,
   shouldIncludePauseSegment,
 } from '../category-pie-chart.utils';
 
@@ -42,6 +43,7 @@ describe('buildCategoryPieChartData', () => {
     const data = buildCategoryPieChartData(baseStats, {
       treatPausesAsSeparateState: true,
       pauseSegmentLabel: 'Pause',
+      unaccountedSegmentLabel: 'Unaccounted',
     });
 
     expect(data).toHaveLength(3);
@@ -55,6 +57,7 @@ describe('buildCategoryPieChartData', () => {
     const data = buildCategoryPieChartData(baseStats, {
       treatPausesAsSeparateState: true,
       pauseSegmentLabel: 'Pause',
+      unaccountedSegmentLabel: 'Unaccounted',
     });
 
     const total = data.reduce((sum, segment) => sum + segment.value, 0);
@@ -88,6 +91,7 @@ describe('buildCategoryPieChartData', () => {
     const data = buildCategoryPieChartData(statsWithPausesIncluded, {
       treatPausesAsSeparateState: false,
       pauseSegmentLabel: 'Pause',
+      unaccountedSegmentLabel: 'Unaccounted',
     });
 
     expect(data).toHaveLength(2);
@@ -96,11 +100,85 @@ describe('buildCategoryPieChartData', () => {
     const total = data.reduce((sum, segment) => sum + segment.value, 0);
     expect(total).toBeCloseTo(100, 5);
   });
+
+  it('adds an unaccounted segment when the first observable starts after the observation START', () => {
+    // Observation window is 10 min, but the first observable of the category only
+    // appears 1 min in: that lead time isn't covered by any observable or pause.
+    const statsWithLateFirstObservable = {
+      observationDuration: 9 * 60 * 1000, // 10 min window minus 1 min pause
+      pauseDuration: 1 * 60 * 1000,
+      observables: [
+        {
+          observableName: 'obsA',
+          onDuration: 3 * 60 * 1000,
+          onPercentage: (3 / 9) * 100,
+          onCount: 1,
+        },
+        {
+          observableName: 'obsB',
+          onDuration: 5 * 60 * 1000,
+          onPercentage: (5 / 9) * 100,
+          onCount: 1,
+        },
+      ],
+    };
+
+    const data = buildCategoryPieChartData(statsWithLateFirstObservable, {
+      treatPausesAsSeparateState: true,
+      pauseSegmentLabel: 'Pause',
+      unaccountedSegmentLabel: 'Unaccounted',
+    });
+
+    expect(data).toHaveLength(4);
+    expect(data[3]).toEqual({
+      label: 'Unaccounted',
+      // 1 min gap out of the full 10 min window (9 min + 1 min pause)
+      value: 10,
+    });
+
+    const total = data.reduce((sum, segment) => sum + segment.value, 0);
+    expect(total).toBeCloseTo(100, 5);
+  });
+
+  it('does not add an unaccounted segment when observables fully cover the window', () => {
+    const data = buildCategoryPieChartData(baseStats, {
+      treatPausesAsSeparateState: true,
+      pauseSegmentLabel: 'Pause',
+      unaccountedSegmentLabel: 'Unaccounted',
+    });
+
+    expect(data.some((segment) => segment.label === 'Unaccounted')).toBe(false);
+  });
+});
+
+describe('calculateUnaccountedPieDuration', () => {
+  it('returns the gap between the observation window and the accounted durations', () => {
+    const stats = {
+      observationDuration: 9 * 60 * 1000,
+      pauseDuration: 1 * 60 * 1000,
+      observables: [
+        { observableName: 'obsA', onDuration: 3 * 60 * 1000, onPercentage: 0, onCount: 1 },
+        { observableName: 'obsB', onDuration: 5 * 60 * 1000, onPercentage: 0, onCount: 1 },
+      ],
+    };
+
+    expect(calculateUnaccountedPieDuration(stats, true)).toBe(1 * 60 * 1000);
+  });
+
+  it('returns 0 when there is no gap', () => {
+    expect(calculateUnaccountedPieDuration(baseStats, true)).toBe(0);
+  });
 });
 
 describe('buildCategoryPieChartColors', () => {
   it('appends the pause color only when the pause segment is shown', () => {
     expect(buildCategoryPieChartColors(true, 60_000)).toHaveLength(9);
     expect(buildCategoryPieChartColors(false, 60_000)).toHaveLength(8);
+  });
+
+  it('appends the unaccounted color only when requested', () => {
+    expect(buildCategoryPieChartColors(true, 60_000, undefined, true)).toHaveLength(10);
+    expect(buildCategoryPieChartColors(true, 60_000, undefined, false)).toHaveLength(9);
+    expect(buildCategoryPieChartColors(false, 0, undefined, true)).toHaveLength(9);
   });
 });

--- a/front/src/composables/use-statistics/__tests__/statistics-export.utils.test.ts
+++ b/front/src/composables/use-statistics/__tests__/statistics-export.utils.test.ts
@@ -41,6 +41,21 @@ describe('resolveTotalCategoryDuration', () => {
       }),
     ).toBe(1000);
   });
+
+  it('prefers observationDuration over the sum of observable durations, so an unattributed gap is not silently absorbed', () => {
+    // First observable starts after the observation window's true start: the
+    // sum of on-durations (1000) is less than the real window (1200).
+    expect(
+      resolveTotalCategoryDuration({
+        totalCategoryDuration: 1000,
+        observationDuration: 1200,
+        observables: [
+          { onDuration: 250 } as any,
+          { onDuration: 750 } as any,
+        ],
+      }),
+    ).toBe(1200);
+  });
 });
 
 describe('formatObservableOnPercentage', () => {

--- a/front/src/composables/use-statistics/category-pie-chart.utils.ts
+++ b/front/src/composables/use-statistics/category-pie-chart.utils.ts
@@ -9,6 +9,7 @@ export interface PieChartSegment {
 export interface BuildCategoryPieChartDataOptions {
   treatPausesAsSeparateState: boolean;
   pauseSegmentLabel: string;
+  unaccountedSegmentLabel: string;
 }
 
 export const CATEGORY_PIE_CHART_BASE_COLORS = [
@@ -24,6 +25,14 @@ export const CATEGORY_PIE_CHART_BASE_COLORS = [
 
 export const CATEGORY_PIE_CHART_PAUSE_COLOR = '#9E9E9E';
 
+// Represents the portion of the observation window not covered by any observable
+// or pause (e.g. before the first observable of the category was recorded).
+// A pale, low-contrast gray (lighter than the pause color) so it reads as "no
+// data" rather than as another category. Must be a plain hex string: amCharts5's
+// ColorSet doesn't carry alpha, and its CSS rgba() parser rejects spaces after
+// commas, so an rgba() value here silently falls through to a wrong color.
+export const CATEGORY_PIE_CHART_UNACCOUNTED_COLOR = '#D6D6D6';
+
 export function shouldIncludePauseSegment(
   treatPausesAsSeparateState: boolean,
   pauseDuration: number,
@@ -31,24 +40,66 @@ export function shouldIncludePauseSegment(
   return treatPausesAsSeparateState && pauseDuration > 0;
 }
 
+type PieStatsInput = Pick<
+  ICategoryStatistics,
+  'observables' | 'totalCategoryDuration' | 'pauseDuration' | 'observationDuration'
+>;
+
+function resolvePieDenominator(
+  stats: PieStatsInput,
+  includePauseSegment: boolean,
+): number {
+  const totalWindow = resolveTotalCategoryDuration(stats);
+  const pauseDuration = stats.pauseDuration || 0;
+  return includePauseSegment ? totalWindow + pauseDuration : totalWindow;
+}
+
+/**
+ * Duration (ms) within the observation window not covered by any observable's "on"
+ * period nor by the pause segment. This happens e.g. when the first observable of a
+ * category is recorded some time after the observation START: that lead time isn't
+ * attributable to any observable and must be shown as an empty slice, not silently
+ * dropped (which would make the other slices stretch to fill the whole pie).
+ */
+export function calculateUnaccountedPieDuration(
+  stats: PieStatsInput,
+  treatPausesAsSeparateState: boolean,
+): number {
+  if (!stats.observables || stats.observables.length === 0) {
+    return 0;
+  }
+
+  const pauseDuration = stats.pauseDuration || 0;
+  const includePauseSegment = shouldIncludePauseSegment(
+    treatPausesAsSeparateState,
+    pauseDuration,
+  );
+  const pieDenominator = resolvePieDenominator(stats, includePauseSegment);
+  if (pieDenominator <= 0) {
+    return 0;
+  }
+
+  const accountedDuration =
+    stats.observables.reduce((sum, obs) => sum + Math.max(0, obs.onDuration || 0), 0) +
+    (includePauseSegment ? pauseDuration : 0);
+
+  return Math.max(0, pieDenominator - accountedDuration);
+}
+
 export function buildCategoryPieChartData(
-  stats: Pick<ICategoryStatistics, 'observables' | 'totalCategoryDuration' | 'pauseDuration'>,
+  stats: PieStatsInput,
   options: BuildCategoryPieChartDataOptions,
 ): PieChartSegment[] {
   if (!stats.observables || stats.observables.length === 0) {
     return [];
   }
 
-  const totalCategoryDuration = resolveTotalCategoryDuration(stats);
   const pauseDuration = stats.pauseDuration || 0;
   const includePauseSegment = shouldIncludePauseSegment(
     options.treatPausesAsSeparateState,
     pauseDuration,
   );
-
-  const pieDenominator = includePauseSegment
-    ? totalCategoryDuration + pauseDuration
-    : totalCategoryDuration;
+  const pieDenominator = resolvePieDenominator(stats, includePauseSegment);
 
   const data = stats.observables
     .filter((obs) => {
@@ -57,12 +108,7 @@ export function buildCategoryPieChartData(
       return hasDuration || hasCount;
     })
     .map((obs) => {
-      let value: number;
-      if (includePauseSegment && pieDenominator > 0) {
-        value = (obs.onDuration / pieDenominator) * 100;
-      } else {
-        value = Math.max(0, obs.onPercentage || 0);
-      }
+      const value = pieDenominator > 0 ? (obs.onDuration / pieDenominator) * 100 : 0;
       return {
         label: obs.observableName,
         value,
@@ -76,17 +122,35 @@ export function buildCategoryPieChartData(
     });
   }
 
-  return data.length > 0 ? data : [];
+  if (pieDenominator > 0) {
+    const unaccountedDuration = calculateUnaccountedPieDuration(
+      stats,
+      options.treatPausesAsSeparateState,
+    );
+    if (unaccountedDuration > 0) {
+      data.push({
+        label: options.unaccountedSegmentLabel,
+        value: (unaccountedDuration / pieDenominator) * 100,
+      });
+    }
+  }
+
+  return data;
 }
 
 export function buildCategoryPieChartColors(
   treatPausesAsSeparateState: boolean,
   pauseDuration: number,
   baseColors: string[] = CATEGORY_PIE_CHART_BASE_COLORS,
+  hasUnaccountedSegment = false,
 ): string[] {
-  if (shouldIncludePauseSegment(treatPausesAsSeparateState, pauseDuration)) {
-    return [...baseColors, CATEGORY_PIE_CHART_PAUSE_COLOR];
+  const colors = shouldIncludePauseSegment(treatPausesAsSeparateState, pauseDuration)
+    ? [...baseColors, CATEGORY_PIE_CHART_PAUSE_COLOR]
+    : [...baseColors];
+
+  if (hasUnaccountedSegment) {
+    colors.push(CATEGORY_PIE_CHART_UNACCOUNTED_COLOR);
   }
 
-  return baseColors;
+  return colors;
 }

--- a/front/src/composables/use-statistics/statistics-export.utils.ts
+++ b/front/src/composables/use-statistics/statistics-export.utils.ts
@@ -18,8 +18,20 @@ export const buildStatisticsExportFileName = (observationName?: string | null): 
 };
 
 export const resolveTotalCategoryDuration = (
-  category: Pick<ICategoryStatistics, 'totalCategoryDuration' | 'observables'>,
+  category: Pick<
+    ICategoryStatistics,
+    'totalCategoryDuration' | 'observables' | 'observationDuration'
+  >,
 ): number => {
+  // Prefer the real observation window (first START to last STOP): it's the
+  // only basis that accounts for time not covered by any observable (e.g. a
+  // gap before the first observable of the category was recorded). Falling
+  // back to the sum of on-durations silently absorbs that gap into the other
+  // percentages instead of exposing it.
+  if (category.observationDuration && category.observationDuration > 0) {
+    return category.observationDuration;
+  }
+
   let totalCategoryDuration = category.totalCategoryDuration || 0;
   if (totalCategoryDuration === 0) {
     totalCategoryDuration = category.observables.reduce(

--- a/front/src/i18n/en-US/index.ts
+++ b/front/src/i18n/en-US/index.ts
@@ -392,6 +392,7 @@ export default {
     categoryOccurrencesChartTitle: 'Number of occurrences',
     chartNoData: 'No data',
     pauseSegmentLabel: 'Pause',
+    unaccountedSegmentLabel: 'Not recorded',
     occurrenceCountOne: '{count} occurrence',
     occurrenceCountOther: '{count} occurrences',
     chartSeriesOccurrences: 'Occurrences',

--- a/front/src/i18n/fr/index.ts
+++ b/front/src/i18n/fr/index.ts
@@ -397,6 +397,7 @@ export default {
     categoryOccurrencesChartTitle: 'Nombre d\'occurrences',
     chartNoData: 'Aucune donnée',
     pauseSegmentLabel: 'Pause',
+    unaccountedSegmentLabel: 'Non renseigné',
     occurrenceCountOne: '{count} occurrence',
     occurrenceCountOther: '{count} occurrences',
     chartSeriesOccurrences: 'Occurrences',

--- a/front/src/pages/userspace/statistics/_components/CategoryStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/CategoryStatisticsView.vue
@@ -70,7 +70,10 @@ import {
   buildCategoryPieChartColors,
   buildCategoryPieChartData,
   calculateUnaccountedPieDuration,
+  CATEGORY_PIE_CHART_BASE_COLORS,
 } from 'src/composables/use-statistics/category-pie-chart.utils';
+import { getObservableGraphPreferences } from '@services/observations/protocol-graph-preferences.utils';
+import { DEFAULT_GRAPH_COLOR } from '@actograph/graph';
 import AmChartsPieChart from './AmChartsPieChart.vue';
 import AmChartsBarChart from './AmChartsBarChart.vue';
 
@@ -166,13 +169,40 @@ export default defineComponent({
       });
     });
 
+    const resolveObservableColor = (observableId: string, index: number): string => {
+      const protocol = observation.protocol?.sharedState?.currentProtocol;
+      const preferences = protocol
+        ? getObservableGraphPreferences(observableId, protocol)
+        : null;
+      return (
+        preferences?.color ||
+        CATEGORY_PIE_CHART_BASE_COLORS[index % CATEGORY_PIE_CHART_BASE_COLORS.length]
+      );
+    };
+
+    const resolveCategoryColor = (categoryId: string | null): string => {
+      const protocol = observation.protocol?.sharedState?.currentProtocol;
+      const category = protocol?._items?.find(
+        (item: { type?: string; id?: string }) =>
+          item.type === 'category' && item.id === categoryId,
+      ) as { graphPreferences?: { color?: string } } | undefined;
+      return category?.graphPreferences?.color || DEFAULT_GRAPH_COLOR;
+    };
+
     const pieChartColors = computed(() => {
       const stats = statistics.sharedState.categoryStatistics;
+      const observables =
+        stats?.observables?.filter(
+          (obs) => obs.onDuration > 0 || obs.onCount > 0,
+        ) || [];
+      const resolvedColors = observables.map((obs, index) =>
+        resolveObservableColor(obs.observableId, index),
+      );
 
       return buildCategoryPieChartColors(
         statistics.sharedState.treatPausesAsSeparateState,
         stats?.pauseDuration || 0,
-        undefined,
+        resolvedColors,
         unaccountedPieDuration.value > 0,
       );
     });
@@ -228,7 +258,7 @@ export default defineComponent({
     });
 
     const barChartColors = computed(() => {
-      return '#1976D2';
+      return resolveCategoryColor(state.selectedCategoryId);
     });
 
     return {

--- a/front/src/pages/userspace/statistics/_components/CategoryStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/CategoryStatisticsView.vue
@@ -69,6 +69,7 @@ import {
 import {
   buildCategoryPieChartColors,
   buildCategoryPieChartData,
+  calculateUnaccountedPieDuration,
 } from 'src/composables/use-statistics/category-pie-chart.utils';
 import AmChartsPieChart from './AmChartsPieChart.vue';
 import AmChartsBarChart from './AmChartsBarChart.vue';
@@ -139,6 +140,19 @@ export default defineComponent({
       { immediate: true },
     );
 
+    // Shared by pieChartData (to decide whether to push the segment) and
+    // pieChartColors (to decide whether to append its color), so the two
+    // arrays can't drift out of sync by recomputing this independently.
+    const unaccountedPieDuration = computed(() => {
+      const stats = statistics.sharedState.categoryStatistics;
+      return stats
+        ? calculateUnaccountedPieDuration(
+            stats,
+            statistics.sharedState.treatPausesAsSeparateState,
+          )
+        : 0;
+    });
+
     const pieChartData = computed(() => {
       const stats = statistics.sharedState.categoryStatistics;
       if (!stats) {
@@ -148,6 +162,7 @@ export default defineComponent({
       return buildCategoryPieChartData(stats, {
         treatPausesAsSeparateState: statistics.sharedState.treatPausesAsSeparateState,
         pauseSegmentLabel: t('statisticsUi.pauseSegmentLabel'),
+        unaccountedSegmentLabel: t('statisticsUi.unaccountedSegmentLabel'),
       });
     });
 
@@ -157,6 +172,8 @@ export default defineComponent({
       return buildCategoryPieChartColors(
         statistics.sharedState.treatPausesAsSeparateState,
         stats?.pauseDuration || 0,
+        undefined,
+        unaccountedPieDuration.value > 0,
       );
     });
 

--- a/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
@@ -146,10 +146,13 @@ import {
   IConditionGroup,
   IObservableCondition,
 } from '@services/observations/statistics.interface';
+import { getObservableGraphPreferences } from '@services/observations/protocol-graph-preferences.utils';
+import { DEFAULT_GRAPH_COLOR } from '@actograph/graph';
 import {
   buildCategoryPieChartColors,
   buildCategoryPieChartData,
   calculateUnaccountedPieDuration,
+  CATEGORY_PIE_CHART_BASE_COLORS,
 } from 'src/composables/use-statistics/category-pie-chart.utils';
 import AmChartsPieChart from './AmChartsPieChart.vue';
 import AmChartsBarChart from './AmChartsBarChart.vue';
@@ -341,11 +344,40 @@ export default defineComponent({
       });
     });
 
+    const resolveObservableColor = (observableId: string, index: number): string => {
+      const protocol = observation.protocol?.sharedState?.currentProtocol;
+      const preferences = protocol
+        ? getObservableGraphPreferences(observableId, protocol)
+        : null;
+      return (
+        preferences?.color ||
+        CATEGORY_PIE_CHART_BASE_COLORS[index % CATEGORY_PIE_CHART_BASE_COLORS.length]
+      );
+    };
+
+    const resolveCategoryColor = (categoryId: string | null): string => {
+      const protocol = observation.protocol?.sharedState?.currentProtocol;
+      const category = protocol?._items?.find(
+        (item: { type?: string; id?: string }) =>
+          item.type === 'category' && item.id === categoryId,
+      ) as { graphPreferences?: { color?: string } } | undefined;
+      return category?.graphPreferences?.color || DEFAULT_GRAPH_COLOR;
+    };
+
     const pieChartColors = computed(() => {
+      const stats = statistics.sharedState.conditionalStatistics;
+      const observables =
+        stats?.targetCategory?.observables?.filter(
+          (obs) => obs.onDuration > 0 || obs.onCount > 0,
+        ) || [];
+      const resolvedColors = observables.map((obs, index) =>
+        resolveObservableColor(obs.observableId, index),
+      );
+
       return buildCategoryPieChartColors(
         false,
         0,
-        undefined,
+        resolvedColors,
         unaccountedPieDuration.value > 0,
       );
     });
@@ -369,7 +401,7 @@ export default defineComponent({
     });
 
     const barChartColors = computed(() => {
-      return '#1976D2';
+      return resolveCategoryColor(state.targetCategoryId);
     });
 
     return {

--- a/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
@@ -146,6 +146,11 @@ import {
   IConditionGroup,
   IObservableCondition,
 } from '@services/observations/statistics.interface';
+import {
+  buildCategoryPieChartColors,
+  buildCategoryPieChartData,
+  calculateUnaccountedPieDuration,
+} from 'src/composables/use-statistics/category-pie-chart.utils';
 import AmChartsPieChart from './AmChartsPieChart.vue';
 import AmChartsBarChart from './AmChartsBarChart.vue';
 
@@ -312,94 +317,37 @@ export default defineComponent({
       },
     };
 
+    // The conditional tab doesn't expose a pause-as-separate-state toggle, so
+    // its pie never shows a pause segment; it only needs the "unaccounted"
+    // gap segment for consistency with the category tab (see
+    // category-pie-chart.utils.ts / calculateUnaccountedPieDuration).
+    const unaccountedPieDuration = computed(() => {
+      const stats = statistics.sharedState.conditionalStatistics;
+      return stats?.targetCategory
+        ? calculateUnaccountedPieDuration(stats.targetCategory, false)
+        : 0;
+    });
+
     const pieChartData = computed(() => {
       const stats = statistics.sharedState.conditionalStatistics;
       if (!stats || !stats.targetCategory || !stats.targetCategory.observables) {
-        console.debug('[ConditionalStatisticsView] No statistics data available');
         return [];
       }
 
-      console.debug('[ConditionalStatisticsView] Statistics data:', {
-        observables: stats.targetCategory.observables,
-        totalCategoryDuration: stats.targetCategory.totalCategoryDuration,
-        pauseDuration: stats.targetCategory.pauseDuration,
+      return buildCategoryPieChartData(stats.targetCategory, {
+        treatPausesAsSeparateState: false,
+        pauseSegmentLabel: t('statisticsUi.pauseSegmentLabel'),
+        unaccountedSegmentLabel: t('statisticsUi.unaccountedSegmentLabel'),
       });
-
-      // Calculate total duration from observables (same logic as CategoryStatisticsView)
-      let totalCategoryDuration = stats.targetCategory.totalCategoryDuration || 0;
-      if (totalCategoryDuration === 0) {
-        // Fallback: calculate from observables if backend returned 0
-        totalCategoryDuration = stats.targetCategory.observables.reduce(
-          (sum, obs) => sum + (obs.onDuration || 0),
-          0,
-        );
-        console.debug(
-          '[ConditionalStatisticsView] Calculated totalCategoryDuration from observables:',
-          totalCategoryDuration,
-        );
-      }
-
-      console.debug('[ConditionalStatisticsView] Durations:', {
-        totalCategoryDuration,
-      });
-
-      // Build data array with observables
-      // Include all observables that have either duration or count > 0 (same as CategoryStatisticsView)
-      const data = stats.targetCategory.observables
-        .filter((obs) => {
-          const hasDuration = obs.onDuration > 0;
-          const hasCount = obs.onCount > 0;
-          const included = hasDuration || hasCount;
-          
-          console.debug(`[ConditionalStatisticsView] Observable ${obs.observableName}:`, {
-            onDuration: obs.onDuration,
-            onPercentage: obs.onPercentage,
-            onCount: obs.onCount,
-            hasDuration,
-            hasCount,
-            included,
-          });
-          
-          return included;
-        })
-        .map((obs) => {
-          let percentage = obs.onPercentage || 0;
-          
-          // Recalculate percentage if needed (same logic as CategoryStatisticsView)
-          if (totalCategoryDuration > 0 && percentage === 0 && obs.onDuration > 0) {
-            percentage = (obs.onDuration / totalCategoryDuration) * 100;
-          }
-          
-          console.debug(`[ConditionalStatisticsView] Mapped observable ${obs.observableName}:`, {
-            originalPercentage: obs.onPercentage,
-            calculatedPercentage: totalCategoryDuration > 0 ? (obs.onDuration / totalCategoryDuration) * 100 : 0,
-            finalPercentage: percentage,
-            onDuration: obs.onDuration,
-            totalCategoryDuration,
-          });
-          
-          return {
-            label: obs.observableName,
-            value: Math.max(0, percentage), // Ensure non-negative (same as CategoryStatisticsView)
-          };
-        });
-
-      console.debug('[ConditionalStatisticsView] Final pie chart data:', data);
-      return data.length > 0 ? data : [];
     });
 
     const pieChartColors = computed(() => {
-      const colors = [
-        '#1976D2',
-        '#388E3C',
-        '#F57C00',
-        '#7B1FA2',
-        '#C2185B',
-        '#00796B',
-        '#0288D1',
-        '#5D4037',
-      ];
-      return colors;
+      return buildCategoryPieChartColors(
+        false,
+        0,
+        undefined,
+        unaccountedPieDuration.value > 0,
+      );
     });
 
     const barChartData = computed(() => {

--- a/front/src/services/observations/statistics.interface.ts
+++ b/front/src/services/observations/statistics.interface.ts
@@ -20,6 +20,12 @@ export interface ICategoryStatistics {
   observables: IObservableStatistics[];
   pauseDuration?: number; // Total pause duration in milliseconds for this observation
   totalCategoryDuration?: number; // Total duration of all observables in this category (milliseconds)
+  // The window used as the percentage basis (milliseconds): the observation
+  // span for category statistics, or the filtered periods' total duration for
+  // conditional statistics. Optional for backward compatibility; consumers
+  // fall back to totalCategoryDuration (sum of observable on-durations) when
+  // it's absent.
+  observationDuration?: number;
 }
 
 export interface IObservableStatistics {

--- a/packages/core/src/__tests__/statistics/category-statistics.test.ts
+++ b/packages/core/src/__tests__/statistics/category-statistics.test.ts
@@ -77,6 +77,26 @@ describe('category-statistics', () => {
       // Total duration = 10 min - 1 min pause = 9 min
       expect(obsA?.onPercentage).toBeCloseTo((3 / 9) * 100, 5);
       expect(stats.pauseDuration).toBe(1 * 60 * 1000);
+      expect(stats.observationDuration).toBe(9 * 60 * 1000);
+    });
+
+    it('exposes an observationDuration larger than the sum of observable durations when the first observable starts after START', () => {
+      // obsA starts 1 min after START, so that 1 min isn't covered by any observable.
+      const stats = calculateCategoryStatistics(
+        continuousCategory,
+        baseReadings,
+        observationStart,
+        observationEnd,
+      );
+
+      const totalObservableDuration = stats.observables.reduce(
+        (sum, obs) => sum + obs.onDuration,
+        0,
+      );
+
+      expect(stats.observationDuration).toBe(9 * 60 * 1000);
+      expect(totalObservableDuration).toBeLessThan(stats.observationDuration!);
+      expect(stats.observationDuration! - totalObservableDuration).toBe(1 * 60 * 1000);
     });
 
     it('should include pauses in total duration and on durations when includePauses is true', () => {

--- a/packages/core/src/__tests__/statistics/conditional-statistics.test.ts
+++ b/packages/core/src/__tests__/statistics/conditional-statistics.test.ts
@@ -123,4 +123,33 @@ describe('conditional-statistics', () => {
     ]);
     expect(result.categoryStatistics.totalCategoryDuration).toBe(2 * 60 * 1000);
   });
+
+  it('exposes observationDuration as the filtered-periods window and scopes percentages to it, not to the sum of on-durations', () => {
+    const result = calculateConditionalStatistics(readings, protocolItems, {
+      targetCategoryId: 'category-1',
+      groupOperator: ConditionOperatorEnum.OR,
+      conditionGroups: [
+        {
+          operator: ConditionOperatorEnum.OR,
+          observables: [
+            {
+              observableName: 'A',
+              state: ObservableStateEnum.OFF,
+            },
+          ],
+        },
+      ],
+    });
+
+    // Filtered window is 1 min + 2 min = 3 min, but only 2 min are covered by
+    // observable B: the remaining 1 min (10:00-10:01) isn't attributable to any
+    // observable and must not be silently absorbed into B's percentage.
+    expect(result.categoryStatistics.observationDuration).toBe(3 * 60 * 1000);
+
+    const obsB = result.categoryStatistics.observables.find(
+      (o) => o.observableName === 'B',
+    );
+    expect(obsB?.onPercentage).toBeCloseTo((2 / 3) * 100, 5);
+    expect(obsB?.onPercentage).not.toBeCloseTo(100, 5);
+  });
 });

--- a/packages/core/src/statistics/category-statistics.ts
+++ b/packages/core/src/statistics/category-statistics.ts
@@ -239,6 +239,7 @@ export function calculateCategoryStatistics(
     observables: observableStats,
     pauseDuration,
     totalCategoryDuration,
+    observationDuration: totalDuration,
   };
 }
 

--- a/packages/core/src/statistics/conditional-statistics.ts
+++ b/packages/core/src/statistics/conditional-statistics.ts
@@ -181,18 +181,30 @@ export function calculateCategoryStatisticsForPeriods(
     },
   );
 
-  // Calculate total category duration (sum of all observable durations)
+  // Total duration of all observables (kept as a secondary "active time" metric)
   const totalCategoryDuration = observableStats.reduce(
     (sum, obs) => sum + (obs.onDuration || 0),
     0,
   );
 
-  // Recalculate percentages within the category (not relative to total filtered duration)
+  // Real window under analysis: the total duration of the filtered periods
+  // themselves, not just the sum of on-durations. Using the periods' own
+  // duration as the percentage basis (instead of self-normalizing against
+  // totalCategoryDuration) means any time within those periods not covered
+  // by an observable shows up as a gap rather than being silently absorbed
+  // into the other observables' percentages.
+  const periodsDuration = periods.reduce(
+    (sum, period) => sum + (period.end.getTime() - period.start.getTime()),
+    0,
+  );
+  const percentageBasis = periodsDuration > 0 ? periodsDuration : totalCategoryDuration;
+
+  // Recalculate percentages within the filtered window
   const observableStatsWithCategoryPercentage = observableStats.map((obs) => ({
     ...obs,
     onPercentage:
-      totalCategoryDuration > 0
-        ? (obs.onDuration / totalCategoryDuration) * 100
+      percentageBasis > 0
+        ? (obs.onDuration / percentageBasis) * 100
         : 0,
   }));
 
@@ -207,6 +219,7 @@ export function calculateCategoryStatisticsForPeriods(
     observables: observableStatsWithCategoryPercentage,
     pauseDuration,
     totalCategoryDuration,
+    observationDuration: periodsDuration > 0 ? periodsDuration : undefined,
   };
 }
 

--- a/packages/core/src/types/statistics.types.ts
+++ b/packages/core/src/types/statistics.types.ts
@@ -38,6 +38,14 @@ export interface ICategoryStatistics {
   observables: IObservableStatistics[];
   pauseDuration?: number; // Total pause duration in milliseconds for this observation
   totalCategoryDuration?: number; // Total duration of all observables in this category (milliseconds)
+  // The window used as the percentage basis (milliseconds): for
+  // calculateCategoryStatistics, the observation span (first START to last
+  // STOP), pause-excluded unless the caller passes includePauses=true; for
+  // calculateCategoryStatisticsForPeriods (conditional statistics), the total
+  // duration of the filtered periods instead. Optional for backward
+  // compatibility with producers that don't set it, in which case consumers
+  // fall back to totalCategoryDuration (sum of observable on-durations).
+  observationDuration?: number;
 }
 
 /**


### PR DESCRIPTION
## Résumé
- Corrige un bug remonté par une testeuse : changer la couleur d'une catégorie (ou d'un observable) depuis l'onglet Graph n'avait aucun effet sur les diagrammes de l'onglet Statistiques (camembert et histogramme, vues par catégorie et conditionnelles).
- Cause : `pieChartColors` / `barChartColors` utilisaient une palette de couleurs fixe (`CATEGORY_PIE_CHART_BASE_COLORS` / `'#1976D2'`), sans lien avec `category.graphPreferences.color` ni les préférences par observable.
- Les diagrammes lisent désormais la couleur réelle (via `getObservableGraphPreferences` pour le camembert par observable, et `graphPreferences.color` de la catégorie pour l'histogramme), avec repli sur la palette par défaut si aucune couleur personnalisée n'est définie.

## Base
Cette PR est empilée sur #77 (correctif "camembert non couvert"), car le code de couleur s'appuie sur `buildCategoryPieChartColors` / `calculateUnaccountedPieDuration` introduits par ce correctif. À merger après #77 (ou à rebaser sur `main` une fois #77 mergée).

## Test plan
- [x] `vue-tsc --noEmit` : OK
- [x] `jest category-pie-chart` : 12/12 tests passent
- [ ] Vérification manuelle : changer la couleur d'une catégorie dans l'onglet Graph, puis vérifier que le camembert et l'histogramme de l'onglet Statistiques reflètent la nouvelle couleur

🤖 Generated with [Claude Code](https://claude.com/claude-code)