### PR TITLE
fix(statistics): aligner les décimales de la légende sur les étiquettes du camembert

### DIFF
--- a/front/src/pages/userspace/statistics/_components/AmChartsPieChart.vue
+++ b/front/src/pages/userspace/statistics/_components/AmChartsPieChart.vue
@@ -85,6 +85,9 @@ export default defineComponent({
         fontSize: 12,
       });
 
+      // Match legend value format to slice label format (1 decimal)
+      series.set('legendValueText', '{valuePercentTotal.formatNumber(\'#.0\')}%');
+
       // Add tooltip
       series.slices.template.setAll({
         tooltipText: '{category}: {valuePercentTotal.formatNumber(\'#.0\')}% ({value})',


### PR DESCRIPTION
## Résumé
- Les étiquettes autour des diagrammes camembert (statistiques) affichent 1 chiffre après la virgule (`#.0`).
- La légende, elle, utilisait le format par défaut d'amCharts5 (2 chiffres après la virgule), ce qui créait une incohérence visuelle entre légende et étiquettes.
- On force le même format (`#.0`) sur la légende via `series.set('legendValueText', ...)` dans `AmChartsPieChart.vue`.

## Fichier modifié
- `front/src/pages/userspace/statistics/_components/AmChartsPieChart.vue`

## Test plan
- [ ] Ouvrir une observation avec des statistiques par catégorie (camembert)
- [ ] Vérifier que la légende affiche bien 1 seul chiffre après la virgule, identique aux étiquettes autour du diagramme

🤖 Generated with Claude Code