### PR TITLE
fix(protocol): renommage d'observable répercuté dans Observations + unicité des noms

### DIFF
--- a/front/src/composables/use-observation/use-readings.ts
+++ b/front/src/composables/use-observation/use-readings.ts
@@ -607,11 +607,36 @@ export const useReadings = (options: {
     
     /**
      * Sets the selected reading
-     * 
+     *
      * @param reading - The reading to select, or null to clear selection
      */
     selectReading: (reading: IReading | null) => {
       sharedState.selectedReading = reading;
+    },
+
+    /**
+     * Propage le renommage d'un observable du protocole vers les relevés existants.
+     *
+     * Les relevés (IReading) stockent le nom de l'observable sous forme de chaîne
+     * (pas de référence par id), donc renommer un observable dans le protocole ne
+     * met pas à jour les relevés déjà enregistrés avec l'ancien nom. Sans ça,
+     * l'onglet Observations continue d'afficher l'ancien nom en rouge (non reconnu).
+     *
+     * Seuls les relevés de type DATA sont concernés (START/STOP/PAUSE utilisent
+     * des libellés fixes, pas le nom d'un observable).
+     *
+     * @param oldName - Ancien nom de l'observable
+     * @param newName - Nouveau nom de l'observable
+     */
+    renameObservableReadings: (oldName: string, newName: string) => {
+      if (!oldName || !newName || oldName === newName) return;
+
+      sharedState.currentReadings.forEach((reading) => {
+        if (reading.type === ReadingTypeEnum.DATA && reading.name === oldName) {
+          reading.name = newName;
+          reading.updatedAt = new Date();
+        }
+      });
     },
 
     addStartReading: async () => {

--- a/front/src/i18n/en-US/index.ts
+++ b/front/src/i18n/en-US/index.ts
@@ -321,6 +321,8 @@ export default {
       'Cannot edit the category: missing category id',
     errEditCategoryFailed: 'Could not update the category',
     errObservableNameRequired: 'Observable name is required',
+    errObservableNameAlreadyUsed:
+      'The name "{name}" is already used by another observable in this protocol. Please choose a different name.',
     errCannotAddObservableNoProtocolId:
       'Cannot add an observable: missing protocol id',
     errCannotAddObservableNoParent:

--- a/front/src/i18n/fr/index.ts
+++ b/front/src/i18n/fr/index.ts
@@ -325,6 +325,8 @@ export default {
       'Impossible de modifier la catégorie : identifiant de catégorie manquant',
     errEditCategoryFailed: 'Échec de la modification de la catégorie',
     errObservableNameRequired: 'Le nom de l\'observable est obligatoire',
+    errObservableNameAlreadyUsed:
+      'Le nom « {name} » est déjà utilisé par un autre observable de ce protocole. Choisissez un nom différent.',
     errCannotAddObservableNoProtocolId:
       'Impossible d\'ajouter un observable : identifiant de protocole manquant',
     errCannotAddObservableNoParent:

--- a/front/src/pages/userspace/protocol/_components/AddObservableModal.vue
+++ b/front/src/pages/userspace/protocol/_components/AddObservableModal.vue
@@ -59,6 +59,7 @@ import { useQuasar } from 'quasar';
 import {
   ProtocolItem,
   ProtocolItemTypeEnum,
+  isObservableNameInUse,
 } from '@services/observations/protocol.service';
 import { useObservation } from 'src/composables/use-observation';
 import { useI18n } from 'vue-i18n';
@@ -132,6 +133,18 @@ export default defineComponent({
 
       if (!observation.protocol.sharedState.currentProtocol?.id) {
         state.error = t('protocolUi.errCannotAddObservableNoProtocolId');
+        return;
+      }
+
+      if (
+        isObservableNameInUse(
+          observation.protocol.sharedState.currentProtocol._items,
+          state.form.name
+        )
+      ) {
+        state.error = t('protocolUi.errObservableNameAlreadyUsed', {
+          name: state.form.name.trim(),
+        });
         return;
       }
 

--- a/front/src/pages/userspace/protocol/_components/EditObservableModal.vue
+++ b/front/src/pages/userspace/protocol/_components/EditObservableModal.vue
@@ -59,6 +59,7 @@ import { useQuasar } from 'quasar';
 import {
   ProtocolItem,
   ProtocolItemTypeEnum,
+  isObservableNameInUse,
 } from '@services/observations/protocol.service';
 import { useObservation } from 'src/composables/use-observation';
 import { useI18n } from 'vue-i18n';
@@ -166,9 +167,37 @@ export default defineComponent({
         return;
       }
 
+      // Interdit de renommer vers un nom déjà porté par un AUTRE observable
+      // du protocole (les relevés référencent un observable par son nom, pas
+      // par son id : un doublon rendrait impossible de savoir à qui
+      // appartient un relevé historique).
+      if (
+        isObservableNameInUse(
+          observation.protocol.sharedState.currentProtocol._items,
+          state.form.name,
+          state.form.id
+        )
+      ) {
+        state.error = t('protocolUi.errObservableNameAlreadyUsed', {
+          name: state.form.name.trim(),
+        });
+        return;
+      }
+
       try {
         state.loading = true;
         state.error = '';
+
+        const previousName = props.observable?.name || '';
+        // Filet de sécurité pour les protocoles créés avant l'ajout de la
+        // contrainte d'unicité ci-dessus : si l'ancien nom était déjà partagé
+        // par un autre observable (legacy), on ne sait pas sans risque à qui
+        // rattacher chaque relevé historique -> pas de cascade-rename.
+        const previousNameIsAmbiguous = isObservableNameInUse(
+          observation.protocol.sharedState.currentProtocol._items,
+          previousName,
+          state.form.id
+        );
 
         await protocol.methods.editProtocolItem({
           id: state.form.id,
@@ -178,6 +207,18 @@ export default defineComponent({
           order: state.form.order,
           type: ProtocolItemTypeEnum.Observable,
         });
+
+        // Répercute le renommage sur les relevés déjà enregistrés (onglet
+        // Observations), sinon ils continuent de référencer l'ancien nom.
+        // Ignoré si l'ancien nom était ambigu (partagé par un autre observable
+        // encore présent dans le protocole) : impossible de savoir sans risque
+        // quels relevés historiques appartiennent à l'un ou à l'autre.
+        if (previousName && previousName !== state.form.name && !previousNameIsAmbiguous) {
+          observation.readings.methods.renameObservableReadings(
+            previousName,
+            state.form.name
+          );
+        }
 
         $q.notify({
           type: 'positive',

--- a/front/src/services/observations/protocol.service.ts
+++ b/front/src/services/observations/protocol.service.ts
@@ -62,6 +62,43 @@ export interface EditItemDto {
   meta?: Record<string, any>;
 }
 
+/**
+ * Vérifie si un nom d'observable est déjà utilisé dans le protocole (tous
+ * comptes confondus, toutes catégories confondues).
+ *
+ * Les relevés (IReading) référencent un observable par son nom (chaîne),
+ * pas par son id : deux observables homonymes rendraient impossible de
+ * savoir, pour un relevé historique, auquel des deux il appartient (ex. lors
+ * d'un renommage). On interdit donc les doublons dès la création/l'édition.
+ *
+ * @param items - Items du protocole (protocol._items)
+ * @param name - Nom à vérifier
+ * @param excludeObservableId - Id d'observable à ignorer (soi-même, en édition)
+ */
+export const isObservableNameInUse = (
+  items: ProtocolItem[] | undefined | null,
+  name: string,
+  excludeObservableId?: string
+): boolean => {
+  const target = name.trim();
+  if (!items || !target) return false;
+
+  for (const item of items) {
+    if (item.type !== ProtocolItemTypeEnum.Category || !item.children) continue;
+    for (const child of item.children) {
+      if (
+        child.type === ProtocolItemTypeEnum.Observable &&
+        child.id !== excludeObservableId &&
+        child.name.trim() === target
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
 export const protocolService = {
   /**
    * Get protocols with pagination


### PR DESCRIPTION
## Résumé

- Renommer un observable dans le protocole ne se répercutait pas dans l'onglet Observations : les relevés déjà enregistrés stockent le nom de l'observable sous forme de chaîne (pas de référence par id), donc ils gardaient l'ancien nom et s'affichaient en rouge comme « non reconnu ». Le renommage propage désormais le changement de nom vers les relevés existants correspondants.
- Ajout d'un contrôle d'unicité du nom d'observable, à la création ET à l'édition, avec message d'erreur dédié. Sans ce contrôle, deux observables homonymes dans des catégories différentes rendraient le renommage en cascade ambigu (impossible de savoir à quel observable rattacher un relevé historique) — on bloque donc la création du doublon en amont.
- Filet de sécurité conservé pour les protocoles existants qui auraient déjà des doublons hérités (le renommage en cascade est alors ignoré pour ce cas précis, plutôt que de deviner).

## Fichiers modifiés
- `front/src/services/observations/protocol.service.ts` : nouvelle fonction `isObservableNameInUse`
- `front/src/pages/userspace/protocol/_components/AddObservableModal.vue` : blocage à la création d'un nom déjà pris
- `front/src/pages/userspace/protocol/_components/EditObservableModal.vue` : blocage au renommage + cascade vers les relevés existants
- `front/src/composables/use-observation/use-readings.ts` : nouvelle méthode `renameObservableReadings`
- `front/src/i18n/fr/index.ts`, `front/src/i18n/en-US/index.ts` : message d'erreur `errObservableNameAlreadyUsed`

## Test plan
- [ ] Renommer un observable existant ayant déjà des relevés enregistrés → vérifier que l'onglet Observations affiche le nouveau nom sans marquage rouge
- [ ] Tenter de créer un observable avec un nom déjà utilisé par un autre observable du protocole → message d'erreur, pas de création
- [ ] Tenter de renommer un observable vers un nom déjà utilisé par un autre observable du protocole → message d'erreur, pas de renommage
- [ ] `npm run typecheck` (vue-tsc) passe sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)
