### PR TITLE
fix(graph): toggle « Masquer les pauses » inversé

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -452,12 +452,12 @@ Pour les catégories **discrètes** (Évènements, observables one-shot) :
 
 L'option de rendu `maskPauses` (défaut `true`) contrôle l'affichage visuel des pauses sur le graphe.
 
-Quand `maskPauses` est activé :
-- Un **overlay semi-transparent** (rectangle gris, pleine hauteur de la zone de données) est dessiné sur chaque intervalle de pause, **au-dessus** des segments.
-- Les segments continus restent visibles en dessous : l'overlay se superpose, il ne coupe pas les lignes.
+Quand `maskPauses` est activé (défaut) :
+- Les pauses sont **masquées** : aucun overlay n'est dessiné, seuls les segments et marqueurs habituels sont visibles. Les lignes restent continues à travers les pauses, sans indication visuelle qu'une pause a eu lieu.
 
 Quand `maskPauses` est désactivé (`false`) :
-- Aucun overlay n'est dessiné ; seuls les segments et marqueurs habituels sont visibles.
+- Un **overlay semi-transparent** (rectangle gris, pleine hauteur de la zone de données) est dessiné sur chaque intervalle de pause, **au-dessus** des segments, pour révéler où se situent les pauses.
+- Les segments continus restent visibles en dessous : l'overlay se superpose, il ne coupe pas les lignes.
 
 L'option est exposée via `IGraphRenderOptions.maskPauses` (défaut dans `DEFAULT_GRAPH_RENDER_OPTIONS`). Dans l'interface, le toggle **« Masquer les pauses »** du drawer de personnalisation du graphe (`graph-customization-drawer`) pilote cette option.
 
@@ -764,10 +764,10 @@ Les styles peuvent être personnalisés :
 ```typescript
 import { DEFAULT_GRAPH_RENDER_OPTIONS } from '@actograph/graph';
 
-// maskPauses : true par défaut — overlay semi-transparent sur les intervalles de pause
+// maskPauses : true par défaut — pauses masquées (pas d'overlay, segments continus)
 const renderOptions = {
   ...DEFAULT_GRAPH_RENDER_OPTIONS,
-  maskPauses: true, // false pour désactiver l'overlay (segments toujours continus, visibles à travers)
+  maskPauses: false, // false pour révéler les pauses via un overlay semi-transparent
 };
 
 pixiApp.setGraphRenderOptions(renderOptions);

--- a/packages/graph/src/__tests__/pause-overlay.utils.test.ts
+++ b/packages/graph/src/__tests__/pause-overlay.utils.test.ts
@@ -31,7 +31,7 @@ describe('pause-overlay.utils', () => {
       },
     ];
 
-    const rects = computePauseOverlayRects(periods, bounds, getX, { maskPauses: true });
+    const rects = computePauseOverlayRects(periods, bounds, getX, { maskPauses: false });
 
     expect(rects).toHaveLength(2);
     expect(rects[0]).toEqual({
@@ -43,7 +43,7 @@ describe('pause-overlay.utils', () => {
     expect(rects[1]?.width).toBeGreaterThan(0);
   });
 
-  it('returns no rectangles when maskPauses is disabled', () => {
+  it('returns no rectangles when maskPauses is enabled (pauses hidden)', () => {
     const getX = linearXScale(new Date('2024-01-01T10:00:00Z').getTime(), 0.01);
     const periods: IPeriod[] = [
       {
@@ -52,14 +52,14 @@ describe('pause-overlay.utils', () => {
       },
     ];
 
-    expect(computePauseOverlayRects(periods, bounds, getX, { maskPauses: false })).toEqual([]);
-    expect(shouldDrawPauseOverlay(false)).toBe(false);
-    expect(resolveMaskPausesOption({ maskPauses: false })).toBe(false);
+    expect(computePauseOverlayRects(periods, bounds, getX, { maskPauses: true })).toEqual([]);
+    expect(shouldDrawPauseOverlay(true)).toBe(false);
+    expect(resolveMaskPausesOption({ maskPauses: true })).toBe(false);
   });
 
-  it('defaults maskPauses to enabled when option is omitted', () => {
-    expect(shouldDrawPauseOverlay(undefined)).toBe(true);
-    expect(resolveMaskPausesOption({})).toBe(true);
+  it('defaults maskPauses to enabled (hidden) when option is omitted', () => {
+    expect(shouldDrawPauseOverlay(undefined)).toBe(false);
+    expect(resolveMaskPausesOption({})).toBe(false);
   });
 
   it('clips rectangles to the data area horizontal bounds', () => {
@@ -72,7 +72,7 @@ describe('pause-overlay.utils', () => {
       },
     ];
 
-    const rects = computePauseOverlayRects(periods, bounds, getX, { maskPauses: true });
+    const rects = computePauseOverlayRects(periods, bounds, getX, { maskPauses: false });
 
     expect(rects).toHaveLength(1);
     expect(rects[0]?.x).toBe(bounds.leftX);
@@ -87,10 +87,10 @@ describe('pause-overlay.utils', () => {
     };
 
     const zoomedOut = computePauseOverlayRects([period], bounds, linearXScale(origin, 0.0002), {
-      maskPauses: true,
+      maskPauses: false,
     });
     const zoomedIn = computePauseOverlayRects([period], bounds, linearXScale(origin, 0.0004), {
-      maskPauses: true,
+      maskPauses: false,
     });
 
     expect(zoomedOut).toHaveLength(1);
@@ -108,6 +108,6 @@ describe('pause-overlay.utils', () => {
       },
     ];
 
-    expect(computePauseOverlayRects(periods, bounds, getX, { maskPauses: true })).toEqual([]);
+    expect(computePauseOverlayRects(periods, bounds, getX, { maskPauses: false })).toEqual([]);
   });
 });

--- a/packages/graph/src/types/graph-render-options.ts
+++ b/packages/graph/src/types/graph-render-options.ts
@@ -2,7 +2,7 @@
  * Graph-level render options (not per-category protocol preferences).
  */
 export interface IGraphRenderOptions {
-  /** When true (default), draw semi-transparent overlays on pause intervals. */
+  /** When true (default), pauses are hidden: no overlay is drawn on pause intervals. When false, a semi-transparent overlay reveals them. */
   maskPauses?: boolean;
 }
 

--- a/packages/graph/src/utils/pause-overlay.utils.ts
+++ b/packages/graph/src/utils/pause-overlay.utils.ts
@@ -29,7 +29,10 @@ export const DEFAULT_PAUSE_OVERLAY_STYLE: PauseOverlayStyle = {
 export function shouldDrawPauseOverlay(
   maskPauses: boolean | undefined = DEFAULT_GRAPH_RENDER_OPTIONS.maskPauses,
 ): boolean {
-  return maskPauses !== false;
+  // maskPauses === true means "hide pauses": no overlay is drawn, segments
+  // stay seamless. The overlay is only drawn when masking is turned off,
+  // to reveal where the pauses are.
+  return maskPauses === false;
 }
 
 export function resolveMaskPausesOption(


### PR DESCRIPTION
## Résumé
- Le toggle « Masquer les pauses » du drawer de personnalisation du graphe fonctionnait à l'envers : quand il était **actif** (`maskPauses: true`, valeur par défaut), un overlay gris semi-transparent était dessiné **sur** les pauses, les rendant plus visibles au lieu de les masquer.
- La logique dans `shouldDrawPauseOverlay` (`packages/graph/src/utils/pause-overlay.utils.ts`) est inversée : l'overlay n'est désormais dessiné que lorsque `maskPauses` est explicitement `false` (toggle désactivé), ce qui révèle les pauses. Activé (par défaut), aucun overlay n'est dessiné et les segments restent continus, donc les pauses sont réellement invisibles.
- Mise à jour des tests unitaires (`pause-overlay.utils.test.ts`) et de la doc technique (`docs/graph.md`) pour refléter le comportement corrigé.

Remonté par Valérie (ergonome) : "le bouton masquer les pauses fonctionne à l'envers. Quand il est actif on voit la pause."

## Test plan
- [ ] Ouvrir une observation avec des pauses enregistrées, afficher le graphe
- [ ] Vérifier que par défaut (toggle actif) aucune bande grise n'apparaît sur les périodes de pause
- [ ] Désactiver le toggle « Masquer les pauses » et vérifier qu'une bande grise semi-transparente apparaît bien sur les périodes de pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)
