### PR TITLE
fix(statistics): exclure les observables ponctuels des conditions du mode avancé

### DIFF
--- a/front/src/composables/use-statistics/__tests__/conditional-observable-options.utils.test.ts
+++ b/front/src/composables/use-statistics/__tests__/conditional-observable-options.utils.test.ts
@@ -1,0 +1,55 @@
+import { ProtocolItemActionEnum } from '@services/observations/interface';
+import {
+  buildConditionalObservableOptions,
+  isContinuousCategoryAction,
+} from '../conditional-observable-options.utils';
+
+describe('conditional-observable-options.utils', () => {
+  const protocolItems = [
+    {
+      id: 'walk',
+      type: 'category',
+      action: ProtocolItemActionEnum.Continuous,
+      children: [
+        { type: 'observable', name: 'Marche' },
+        { type: 'observable', name: 'Course' },
+      ],
+    },
+    {
+      id: 'events',
+      type: 'category',
+      action: ProtocolItemActionEnum.Discrete,
+      children: [
+        { type: 'observable', name: 'Clic' },
+        { type: 'observable', name: 'Signal' },
+      ],
+    },
+    {
+      id: 'legacy',
+      type: 'category',
+      children: [{ type: 'observable', name: 'LegacyObs' }],
+    },
+  ];
+
+  it('treats missing action as continuous', () => {
+    expect(isContinuousCategoryAction(undefined)).toBe(true);
+    expect(isContinuousCategoryAction(ProtocolItemActionEnum.Continuous)).toBe(true);
+    expect(isContinuousCategoryAction(ProtocolItemActionEnum.Discrete)).toBe(false);
+  });
+
+  it('excludes discrete category observables from condition options', () => {
+    const options = buildConditionalObservableOptions(protocolItems, null);
+
+    expect(options.map((option) => option.value)).toEqual([
+      'Marche',
+      'Course',
+      'LegacyObs',
+    ]);
+  });
+
+  it('excludes observables from the selected target category', () => {
+    const options = buildConditionalObservableOptions(protocolItems, 'walk');
+
+    expect(options.map((option) => option.value)).toEqual(['LegacyObs']);
+  });
+});

--- a/front/src/composables/use-statistics/conditional-observable-options.utils.ts
+++ b/front/src/composables/use-statistics/conditional-observable-options.utils.ts
@@ -1,0 +1,73 @@
+import { ProtocolItemActionEnum } from '@services/observations/interface';
+
+export interface IConditionalObservableOption {
+  label: string;
+  value: string;
+}
+
+export interface IConditionalObservableProtocolItem {
+  type?: string;
+  id?: string;
+  action?: string;
+  children?: Array<{
+    type?: string;
+    name?: string;
+  }>;
+}
+
+export function isContinuousCategoryAction(
+  action?: string | ProtocolItemActionEnum,
+): boolean {
+  return !action || action === ProtocolItemActionEnum.Continuous;
+}
+
+/**
+ * Observables proposables comme conditions du mode avancé :
+ * catégories continues uniquement, hors observables de la catégorie cible.
+ */
+export function buildConditionalObservableOptions(
+  items: IConditionalObservableProtocolItem[],
+  targetCategoryId: string | null,
+): IConditionalObservableOption[] {
+  const targetCategoryObservableNames = new Set<string>();
+
+  if (targetCategoryId) {
+    const targetCategory = items.find(
+      (item) => item.type === 'category' && item.id === targetCategoryId,
+    );
+    if (targetCategory?.children) {
+      for (const child of targetCategory.children) {
+        if (child.type === 'observable' && child.name) {
+          targetCategoryObservableNames.add(child.name);
+        }
+      }
+    }
+  }
+
+  const observables: IConditionalObservableOption[] = [];
+
+  for (const item of items) {
+    if (
+      item.type !== 'category' ||
+      !item.children ||
+      !isContinuousCategoryAction(item.action)
+    ) {
+      continue;
+    }
+
+    for (const child of item.children) {
+      if (
+        child.type === 'observable' &&
+        child.name &&
+        !targetCategoryObservableNames.has(child.name)
+      ) {
+        observables.push({
+          label: child.name,
+          value: child.name,
+        });
+      }
+    }
+  }
+
+  return observables;
+}

--- a/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
@@ -175,7 +175,6 @@ import {
   IObservableCondition,
 } from '@services/observations/statistics.interface';
 import {
-  ProtocolItemActionEnum,
   protocolService,
 } from '@services/observations/protocol.service';
 import {
@@ -189,6 +188,10 @@ import {
 } from 'src/composables/use-statistics/category-pie-chart.utils';
 import AmChartsPieChart from './AmChartsPieChart.vue';
 import AmChartsBarChart from './AmChartsBarChart.vue';
+import {
+  buildConditionalObservableOptions,
+  isContinuousCategoryAction,
+} from 'src/composables/use-statistics/conditional-observable-options.utils';
 
 function formatOccurrenceCount(
   t: (key: string, values?: Record<string, unknown>) => string,
@@ -235,49 +238,20 @@ export default defineComponent({
         return [];
       }
 
-      const targetCategoryObservableNames = new Set<string>();
-      if (state.targetCategoryId) {
-        const targetCategory = protocol._items.find(
-          (item: any) =>
-            item.type === 'category' && item.id === state.targetCategoryId,
-        );
-        if (targetCategory?.children) {
-          for (const child of targetCategory.children) {
-            if (child.type === 'observable' && child.name) {
-              targetCategoryObservableNames.add(child.name);
-            }
-          }
-        }
-      }
-
-      const observables: Array<{ label: string; value: string }> = [];
-      for (const item of protocol._items) {
-        const isContinuous =
-          !item.action || item.action === ProtocolItemActionEnum.Continuous;
-        if (item.type === 'category' && item.children && isContinuous) {
-          for (const child of item.children) {
-            if (
-              child.type === 'observable' &&
-              child.name &&
-              !targetCategoryObservableNames.has(child.name)
-            ) {
-              observables.push({
-                label: child.name,
-                value: child.name,
-              });
-            }
-          }
-        }
-      }
-
-      return observables;
+      return buildConditionalObservableOptions(
+        protocol._items,
+        state.targetCategoryId,
+      );
     });
 
     watch(
-      () => state.targetCategoryId,
+      () => [
+        state.targetCategoryId,
+        observableOptions.value.map((option) => option.value).join('\0'),
+      ],
       () => {
         const validNames = new Set(
-          observableOptions.value.map((opt) => opt.value),
+          observableOptions.value.map((option) => option.value),
         );
         for (const condition of state.conditions) {
           if (
@@ -334,7 +308,7 @@ export default defineComponent({
         return true;
       }
 
-      return !category.action || category.action === ProtocolItemActionEnum.Continuous;
+      return isContinuousCategoryAction(category.action);
     });
 
     const hasNoMatchingConditions = computed(() => {

--- a/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
@@ -252,7 +252,9 @@ export default defineComponent({
 
       const observables: Array<{ label: string; value: string }> = [];
       for (const item of protocol._items) {
-        if (item.type === 'category' && item.children) {
+        const isContinuous =
+          !item.action || item.action === ProtocolItemActionEnum.Continuous;
+        if (item.type === 'category' && item.children && isContinuous) {
           for (const child of item.children) {
             if (
               child.type === 'observable' &&


### PR DESCRIPTION
## Contexte

Suite à la fiche bug transmise par Valérie sur le mode avancé (statistiques conditionnelles) : un observable ponctuel/discret n'a pas de sémantique d'intervalle ON/OFF (c'est un évènement instantané), donc il n'a pas de sens de le proposer comme condition de filtrage.

Le point 2.1 de la fiche (camembert/histogramme affichant des durées pour une catégorie cible ponctuelle) était déjà corrigé dans le code actuel — rien à faire de ce côté.

Cette PR traite le point 2.2 : le sélecteur de conditions proposait tous les observables sans distinction de type.

## Changement

- `observableOptions` dans `ConditionalStatisticsView.vue` filtre désormais les observables pour n'inclure que ceux appartenant à des catégories continues, avec le même critère que le computed `isContinuousCategory` déjà utilisé dans le fichier (`!action || action === Continuous`).

## Hors périmètre (à trancher séparément si besoin)

- Extraction éventuelle de `formatOccurrenceCount` (dupliqué entre `CategoryStatisticsView.vue` et `ConditionalStatisticsView.vue`) en utilitaire partagé.
- Sémantique « occurrence dans la fenêtre » pour utiliser un observable ponctuel comme condition — nécessiterait une évolution dédiée côté `@actograph/core`.

## Vérification

- `eslint` et `vue-tsc --noEmit` passent sans erreur sur le fichier modifié.
- Revue du modèle de données : `_items` et `parseProtocolItems(protocol.items)` pointent vers la même donnée (pas de risque de divergence), et les catégories ne peuvent pas être imbriquées (`AddCategoryDto` n'a pas de `parentId`), donc la boucle à plat sur `protocol._items` est correcte.
- Pas de vérification visuelle en conditions réelles (nécessiterait de monter API + DB + un protocole de test avec catégories mixtes continues/ponctuelles).

🤖 Généré avec [Claude Code](https://claude.com/claude-code)