### PR TITLE
fix(statistics): histogramme du mode avancé toujours en occurrences

### DIFF
--- a/front/src/composables/use-statistics/__tests__/conditional-observable-options.utils.test.ts
+++ b/front/src/composables/use-statistics/__tests__/conditional-observable-options.utils.test.ts
@@ -54,6 +54,32 @@ describe('conditional-observable-options.utils', () => {
     expect(options.map((option) => option.value)).toEqual(['LegacyObs']);
   });
 
+  it('excludes observables from a nested target category', () => {
+    const nestedItems = [
+      {
+        id: 'legacy',
+        type: 'category',
+        children: [{ type: 'observable', name: 'LegacyObs' }],
+      },
+      {
+        id: 'root',
+        type: 'category',
+        children: [
+          {
+            id: 'walk',
+            type: 'category',
+            action: ProtocolItemActionEnum.Continuous,
+            children: [{ type: 'observable', name: 'Marche' }],
+          },
+        ],
+      },
+    ];
+
+    const options = buildConditionalObservableOptions(nestedItems, 'walk');
+
+    expect(options.map((option) => option.value)).toEqual(['LegacyObs']);
+  });
+
   it('resolves whether a category is continuous, including nested categories', () => {
     const nestedItems = [
       {

--- a/front/src/composables/use-statistics/__tests__/conditional-observable-options.utils.test.ts
+++ b/front/src/composables/use-statistics/__tests__/conditional-observable-options.utils.test.ts
@@ -2,6 +2,7 @@ import { ProtocolItemActionEnum } from '@services/observations/interface';
 import {
   buildConditionalObservableOptions,
   isContinuousCategoryAction,
+  resolveCategoryIsContinuous,
 } from '../conditional-observable-options.utils';
 
 describe('conditional-observable-options.utils', () => {
@@ -51,5 +52,26 @@ describe('conditional-observable-options.utils', () => {
     const options = buildConditionalObservableOptions(protocolItems, 'walk');
 
     expect(options.map((option) => option.value)).toEqual(['LegacyObs']);
+  });
+
+  it('resolves whether a category is continuous, including nested categories', () => {
+    const nestedItems = [
+      {
+        id: 'root',
+        type: 'category',
+        children: [
+          {
+            id: 'events',
+            type: 'category',
+            action: ProtocolItemActionEnum.Discrete,
+          },
+        ],
+      },
+    ];
+
+    expect(resolveCategoryIsContinuous(protocolItems, 'walk')).toBe(true);
+    expect(resolveCategoryIsContinuous(protocolItems, 'events')).toBe(false);
+    expect(resolveCategoryIsContinuous(nestedItems, 'events')).toBe(false);
+    expect(resolveCategoryIsContinuous(protocolItems, 'missing')).toBe(true);
   });
 });

--- a/front/src/composables/use-statistics/__tests__/conditional-statistics.utils.test.ts
+++ b/front/src/composables/use-statistics/__tests__/conditional-statistics.utils.test.ts
@@ -1,6 +1,7 @@
 import {
   mapConditionalStatisticsResult,
   shouldUseLocalConditionalStatistics,
+  sumTargetCategoryOccurrences,
 } from '../conditional-statistics.utils';
 import {
   ConditionOperatorEnum,
@@ -46,5 +47,15 @@ describe('conditional-statistics.utils', () => {
   it('uses local conditional statistics when pauses are transparent', () => {
     expect(shouldUseLocalConditionalStatistics(true)).toBe(false);
     expect(shouldUseLocalConditionalStatistics(false)).toBe(true);
+  });
+
+  it('sums onCount across target category observables', () => {
+    expect(
+      sumTargetCategoryOccurrences([
+        { onCount: 2 },
+        { onCount: 3 },
+        { onCount: 0 },
+      ]),
+    ).toBe(5);
   });
 });

--- a/front/src/composables/use-statistics/__tests__/statistics-export.utils.test.ts
+++ b/front/src/composables/use-statistics/__tests__/statistics-export.utils.test.ts
@@ -3,7 +3,6 @@ import {
   buildStatisticsWorksheets,
   formatObservableOnPercentage,
   resolveTotalCategoryDuration,
-  sumTargetCategoryOccurrences,
 } from '../statistics-export.utils';
 
 const t = (key: string) => key;
@@ -70,18 +69,6 @@ describe('formatObservableOnPercentage', () => {
     expect(
       formatObservableOnPercentage({ onDuration: 250, onPercentage: 33.3 }, 1000),
     ).toBe('33.3%');
-  });
-});
-
-describe('sumTargetCategoryOccurrences', () => {
-  it('sums onCount across observables', () => {
-    expect(
-      sumTargetCategoryOccurrences([
-        { onCount: 2 } as any,
-        { onCount: 3 } as any,
-        { onCount: 0 } as any,
-      ]),
-    ).toBe(5);
   });
 });
 

--- a/front/src/composables/use-statistics/__tests__/statistics-export.utils.test.ts
+++ b/front/src/composables/use-statistics/__tests__/statistics-export.utils.test.ts
@@ -3,6 +3,7 @@ import {
   buildStatisticsWorksheets,
   formatObservableOnPercentage,
   resolveTotalCategoryDuration,
+  sumTargetCategoryOccurrences,
 } from '../statistics-export.utils';
 
 const t = (key: string) => key;
@@ -69,6 +70,18 @@ describe('formatObservableOnPercentage', () => {
     expect(
       formatObservableOnPercentage({ onDuration: 250, onPercentage: 33.3 }, 1000),
     ).toBe('33.3%');
+  });
+});
+
+describe('sumTargetCategoryOccurrences', () => {
+  it('sums onCount across observables', () => {
+    expect(
+      sumTargetCategoryOccurrences([
+        { onCount: 2 } as any,
+        { onCount: 3 } as any,
+        { onCount: 0 } as any,
+      ]),
+    ).toBe(5);
   });
 });
 
@@ -156,6 +169,49 @@ describe('buildStatisticsWorksheets', () => {
     });
 
     expect(worksheets?.[0].rows).toHaveLength(2);
+    expect(worksheets?.[0].rows?.[0].onDuration).toBe('500ms');
     expect(worksheets?.[0].rows?.[1].onPercentage).toBe('100.0%');
+  });
+
+  it('exports discrete advanced stats with filtered occurrence summary', () => {
+    const worksheets = buildStatisticsWorksheets({
+      activeTab: 'advanced',
+      generalStatistics: null,
+      categoryStatistics: null,
+      conditionalStatistics: {
+        filteredDuration: 500,
+        conditions: [],
+        targetCategory: {
+          categoryId: 'cat-events',
+          categoryName: 'Events',
+          totalCategoryDuration: 0,
+          observables: [
+            {
+              observableId: 'obs-1',
+              observableName: 'Click',
+              onDuration: 0,
+              onPercentage: 0,
+              onCount: 2,
+            },
+            {
+              observableId: 'obs-2',
+              observableName: 'Signal',
+              onDuration: 0,
+              onPercentage: 0,
+              onCount: 1,
+            },
+          ],
+        },
+      },
+      targetCategoryIsContinuous: false,
+      t,
+      formatDuration,
+    });
+
+    expect(worksheets?.[0].rows?.[0].observableName).toBe(
+      'statisticsUi.colFilteredOccurrences (Events)',
+    );
+    expect(worksheets?.[0].rows?.[0].onDuration).toBe('');
+    expect(worksheets?.[0].rows?.[0].onCount).toBe(3);
   });
 });

--- a/front/src/composables/use-statistics/conditional-observable-options.utils.ts
+++ b/front/src/composables/use-statistics/conditional-observable-options.utils.ts
@@ -8,8 +8,27 @@ export interface IConditionalObservableOption {
 export interface IConditionalObservableProtocolItem {
   type?: string;
   id?: string;
+  name?: string;
   action?: string;
   children?: IConditionalObservableProtocolItem[];
+}
+
+function findProtocolCategory(
+  items: IConditionalObservableProtocolItem[],
+  categoryId: string,
+): IConditionalObservableProtocolItem | null {
+  for (const item of items) {
+    if (item.type === 'category' && item.id === categoryId) {
+      return item;
+    }
+    if (item.children?.length) {
+      const found = findProtocolCategory(item.children, categoryId);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
 }
 
 export function isContinuousCategoryAction(
@@ -22,24 +41,7 @@ export function resolveCategoryIsContinuous(
   items: IConditionalObservableProtocolItem[],
   categoryId: string,
 ): boolean {
-  const findCategory = (
-    nodes: IConditionalObservableProtocolItem[],
-  ): IConditionalObservableProtocolItem | null => {
-    for (const item of nodes) {
-      if (item.type === 'category' && item.id === categoryId) {
-        return item;
-      }
-      if (item.children?.length) {
-        const found = findCategory(item.children);
-        if (found) {
-          return found;
-        }
-      }
-    }
-    return null;
-  };
-
-  const category = findCategory(items);
+  const category = findProtocolCategory(items, categoryId);
   if (!category) {
     return true;
   }
@@ -58,9 +60,7 @@ export function buildConditionalObservableOptions(
   const targetCategoryObservableNames = new Set<string>();
 
   if (targetCategoryId) {
-    const targetCategory = items.find(
-      (item) => item.type === 'category' && item.id === targetCategoryId,
-    );
+    const targetCategory = findProtocolCategory(items, targetCategoryId);
     if (targetCategory?.children) {
       for (const child of targetCategory.children) {
         if (child.type === 'observable' && child.name) {

--- a/front/src/composables/use-statistics/conditional-observable-options.utils.ts
+++ b/front/src/composables/use-statistics/conditional-observable-options.utils.ts
@@ -9,16 +9,42 @@ export interface IConditionalObservableProtocolItem {
   type?: string;
   id?: string;
   action?: string;
-  children?: Array<{
-    type?: string;
-    name?: string;
-  }>;
+  children?: IConditionalObservableProtocolItem[];
 }
 
 export function isContinuousCategoryAction(
   action?: string | ProtocolItemActionEnum,
 ): boolean {
   return !action || action === ProtocolItemActionEnum.Continuous;
+}
+
+export function resolveCategoryIsContinuous(
+  items: IConditionalObservableProtocolItem[],
+  categoryId: string,
+): boolean {
+  const findCategory = (
+    nodes: IConditionalObservableProtocolItem[],
+  ): IConditionalObservableProtocolItem | null => {
+    for (const item of nodes) {
+      if (item.type === 'category' && item.id === categoryId) {
+        return item;
+      }
+      if (item.children?.length) {
+        const found = findCategory(item.children);
+        if (found) {
+          return found;
+        }
+      }
+    }
+    return null;
+  };
+
+  const category = findCategory(items);
+  if (!category) {
+    return true;
+  }
+
+  return isContinuousCategoryAction(category.action);
 }
 
 /**

--- a/front/src/composables/use-statistics/conditional-statistics.utils.ts
+++ b/front/src/composables/use-statistics/conditional-statistics.utils.ts
@@ -30,3 +30,12 @@ export function shouldUseLocalConditionalStatistics(
 ): boolean {
   return !treatPausesAsSeparateState;
 }
+
+export const sumTargetCategoryOccurrences = (
+  observables: Array<{ onCount?: number }> | undefined,
+): number => {
+  if (!observables) {
+    return 0;
+  }
+  return observables.reduce((sum, obs) => sum + (obs.onCount || 0), 0);
+};

--- a/front/src/composables/use-statistics/statistics-export.utils.ts
+++ b/front/src/composables/use-statistics/statistics-export.utils.ts
@@ -5,6 +5,7 @@ import {
   IGeneralStatistics,
   IObservableStatistics,
 } from '@services/observations/statistics.interface';
+import { sumTargetCategoryOccurrences } from './conditional-statistics.utils';
 
 export type StatisticsExportTab = 'general' | 'category' | 'advanced';
 type TranslateFn = (key: string) => string;
@@ -53,14 +54,6 @@ export const formatObservableOnPercentage = (
   return `${percentage.toFixed(1)}%`;
 };
 
-export const sumTargetCategoryOccurrences = (
-  observables: Pick<IObservableStatistics, 'onCount'>[] | undefined,
-): number => {
-  if (!observables) {
-    return 0;
-  }
-  return observables.reduce((sum, obs) => sum + (obs.onCount || 0), 0);
-};
 
 export interface BuildStatisticsWorksheetsInput {
   activeTab: StatisticsExportTab;

--- a/front/src/composables/use-statistics/statistics-export.utils.ts
+++ b/front/src/composables/use-statistics/statistics-export.utils.ts
@@ -53,11 +53,22 @@ export const formatObservableOnPercentage = (
   return `${percentage.toFixed(1)}%`;
 };
 
+export const sumTargetCategoryOccurrences = (
+  observables: Pick<IObservableStatistics, 'onCount'>[] | undefined,
+): number => {
+  if (!observables) {
+    return 0;
+  }
+  return observables.reduce((sum, obs) => sum + (obs.onCount || 0), 0);
+};
+
 export interface BuildStatisticsWorksheetsInput {
   activeTab: StatisticsExportTab;
   generalStatistics: IGeneralStatistics | null;
   categoryStatistics: ICategoryStatistics | null;
   conditionalStatistics: IConditionalStatistics | null;
+  /** Required for advanced tab export; defaults to continuous when omitted. */
+  targetCategoryIsContinuous?: boolean;
   t: TranslateFn;
   formatDuration: FormatDurationFn;
 }
@@ -70,6 +81,7 @@ export const buildStatisticsWorksheets = (
     generalStatistics,
     categoryStatistics,
     conditionalStatistics,
+    targetCategoryIsContinuous = true,
     t,
     formatDuration,
   } = input;
@@ -166,6 +178,20 @@ export const buildStatisticsWorksheets = (
         onCount: obs.onCount,
       }));
 
+    const summaryRow = targetCategoryIsContinuous
+      ? {
+          observableName: `${t('statisticsUi.colFilteredDuration')} (${targetCategory.categoryName})`,
+          onDuration: formatDuration(conditionalStatistics.filteredDuration),
+          onPercentage: '',
+          onCount: '',
+        }
+      : {
+          observableName: `${t('statisticsUi.colFilteredOccurrences')} (${targetCategory.categoryName})`,
+          onDuration: '',
+          onPercentage: '',
+          onCount: sumTargetCategoryOccurrences(targetCategory.observables),
+        };
+
     return [
       {
         name: t('statisticsUi.exportSheetConditional'),
@@ -175,15 +201,7 @@ export const buildStatisticsWorksheets = (
           { header: t('statisticsUi.colOnPercentage'), key: 'onPercentage', width: 20 },
           { header: t('statisticsUi.colOccurrences'), key: 'onCount', width: 15 },
         ],
-        rows: [
-          {
-            observableName: `${t('statisticsUi.colFilteredDuration')} (${targetCategory.categoryName})`,
-            onDuration: formatDuration(conditionalStatistics.filteredDuration),
-            onPercentage: '',
-            onCount: '',
-          },
-          ...observableRows,
-        ],
+        rows: [summaryRow, ...observableRows],
       },
     ];
   }

--- a/front/src/composables/use-statistics/use-statistics-export.ts
+++ b/front/src/composables/use-statistics/use-statistics-export.ts
@@ -3,6 +3,8 @@ import { useI18n } from 'vue-i18n';
 import { useQuasar } from 'quasar';
 import { exportData } from '@lib-improba/utils/export.utils';
 import { useObservation } from 'src/composables/use-observation';
+import { protocolService } from '@services/observations/protocol.service';
+import { resolveCategoryIsContinuous } from './conditional-observable-options.utils';
 import { useStatistics } from './index';
 import {
   buildStatisticsExportFileName,
@@ -22,12 +24,28 @@ export const useStatisticsExport = (getActiveTab: () => StatisticsExportTab) => 
     format: 'excel',
   });
 
+  const targetCategoryIsContinuous = computed(() => {
+    const stats = statistics.sharedState.conditionalStatistics;
+    if (!stats?.targetCategory?.categoryId) {
+      return true;
+    }
+
+    const protocol = observation.protocol?.sharedState?.currentProtocol;
+    if (!protocol) {
+      return true;
+    }
+
+    const items = protocolService.parseProtocolItems(protocol);
+    return resolveCategoryIsContinuous(items, stats.targetCategory.categoryId);
+  });
+
   const worksheetsForExport = computed(() =>
     buildStatisticsWorksheets({
       activeTab: getActiveTab(),
       generalStatistics: statistics.sharedState.generalStatistics,
       categoryStatistics: statistics.sharedState.categoryStatistics,
       conditionalStatistics: statistics.sharedState.conditionalStatistics,
+      targetCategoryIsContinuous: targetCategoryIsContinuous.value,
       t,
       formatDuration: statistics.methods.formatDuration,
     }),

--- a/front/src/i18n/en-US/index.ts
+++ b/front/src/i18n/en-US/index.ts
@@ -422,6 +422,7 @@ export default {
     colOnPercentage: 'On percentage',
     colOccurrences: 'Occurrences',
     colFilteredDuration: 'Filtered duration',
+    colFilteredOccurrences: 'Filtered occurrences',
   },
   graphUi: {
     loading: 'Loading chart...',

--- a/front/src/i18n/en-US/index.ts
+++ b/front/src/i18n/en-US/index.ts
@@ -380,7 +380,6 @@ export default {
     filteredOccurrenceIntroMultiple: 'Total number of occurrences while conditions {conditions} are met:',
     pieShareTitle: 'Distribution (%) of "on" time in category {category} (when {conditions})',
     pieShareTitleNoObservable: 'Distribution (%) of "on" time in category {category}',
-    barOnDurationTitle: 'Absolute “on” durations',
     stateOn: 'On',
     stateOff: 'Off',
     operatorAnd: 'AND',

--- a/front/src/i18n/fr/index.ts
+++ b/front/src/i18n/fr/index.ts
@@ -427,6 +427,7 @@ export default {
     colOnPercentage: 'Pourcentage "on"',
     colOccurrences: 'Occurrences',
     colFilteredDuration: 'Durée filtrée',
+    colFilteredOccurrences: 'Occurrences filtrées',
   },
   graphUi: {
     loading: 'Chargement du graphique...',

--- a/front/src/i18n/fr/index.ts
+++ b/front/src/i18n/fr/index.ts
@@ -385,7 +385,6 @@ export default {
     filteredOccurrenceIntroMultiple: 'Nombre total d\'occurrences lorsque les conditions {conditions} sont valides :',
     pieShareTitle: 'Répartition (%) des temps « on » dans la catégorie {category} (lorsque {conditions})',
     pieShareTitleNoObservable: 'Répartition (%) des temps « on » dans la catégorie {category}',
-    barOnDurationTitle: 'Durées absolues d\'état « on »',
     stateOn: 'On',
     stateOff: 'Off',
     operatorAnd: 'ET',

--- a/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
@@ -192,7 +192,7 @@ import {
   buildConditionalObservableOptions,
   resolveCategoryIsContinuous,
 } from 'src/composables/use-statistics/conditional-observable-options.utils';
-import { sumTargetCategoryOccurrences } from 'src/composables/use-statistics/statistics-export.utils';
+import { sumTargetCategoryOccurrences } from 'src/composables/use-statistics/conditional-statistics.utils';
 
 function formatOccurrenceCount(
   t: (key: string, values?: Record<string, unknown>) => string,
@@ -297,6 +297,8 @@ export default defineComponent({
         return false;
       }
 
+      // Conditions are always drawn from continuous categories, so filteredDuration
+      // reflects whether any matching time window exists.
       return (statistics.sharedState.conditionalStatistics?.filteredDuration || 0) === 0;
     });
 

--- a/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
@@ -190,8 +190,9 @@ import AmChartsPieChart from './AmChartsPieChart.vue';
 import AmChartsBarChart from './AmChartsBarChart.vue';
 import {
   buildConditionalObservableOptions,
-  isContinuousCategoryAction,
+  resolveCategoryIsContinuous,
 } from 'src/composables/use-statistics/conditional-observable-options.utils';
+import { sumTargetCategoryOccurrences } from 'src/composables/use-statistics/statistics-export.utils';
 
 function formatOccurrenceCount(
   t: (key: string, values?: Record<string, unknown>) => string,
@@ -288,27 +289,7 @@ export default defineComponent({
 
       const protocol = observation.protocol.sharedState.currentProtocol;
       const items = protocolService.parseProtocolItems(protocol);
-
-      const findCategory = (nodes: unknown[]): unknown => {
-        for (const item of nodes) {
-          const node = item as { type?: string; id?: string; children?: unknown[] };
-          if (node.type === 'category' && node.id === state.targetCategoryId) {
-            return item;
-          }
-          if (node.children) {
-            const found = findCategory(node.children);
-            if (found) return found;
-          }
-        }
-        return null;
-      };
-
-      const category = findCategory(items) as { action?: string } | null;
-      if (!category) {
-        return true;
-      }
-
-      return isContinuousCategoryAction(category.action);
+      return resolveCategoryIsContinuous(items, state.targetCategoryId);
     });
 
     const hasNoMatchingConditions = computed(() => {
@@ -393,13 +374,11 @@ export default defineComponent({
       return t(`statisticsUi.${keyPrefix}Multiple`, { conditions: names.join(', ') });
     });
 
-    const totalOccurrenceCount = computed(() => {
-      const observables = statistics.sharedState.conditionalStatistics?.targetCategory?.observables;
-      if (!observables) {
-        return 0;
-      }
-      return observables.reduce((sum, obs) => sum + (obs.onCount || 0), 0);
-    });
+    const totalOccurrenceCount = computed(() =>
+      sumTargetCategoryOccurrences(
+        statistics.sharedState.conditionalStatistics?.targetCategory?.observables,
+      ),
+    );
 
     const filteredResultsValueText = computed(() => {
       if (isContinuousCategory.value) {

--- a/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
@@ -432,11 +432,10 @@ export default defineComponent({
         : t('statisticsUi.pieShareTitleNoObservable', { category: categoryName });
     });
 
-    const barChartTitleText = computed(() =>
-      isContinuousCategory.value
-        ? t('statisticsUi.barOnDurationTitle')
-        : t('statisticsUi.categoryOccurrencesChartTitle'),
-    );
+    // L'histogramme compte des évènements (occurrences), pas des durées :
+    // il garde ce sens quel que soit le type de la catégorie cible. La
+    // répartition en durée reste du ressort du camembert (catégories continues).
+    const barChartTitleText = computed(() => t('statisticsUi.categoryOccurrencesChartTitle'));
 
     const unaccountedPieDuration = computed(() => {
       const stats = statistics.sharedState.conditionalStatistics;
@@ -488,24 +487,12 @@ export default defineComponent({
         return [];
       }
 
-      if (!isContinuousCategory.value) {
-        const data = stats.targetCategory.observables
-          .filter((obs) => obs.onCount > 0)
-          .map((obs) => ({
-            label: obs.observableName,
-            value: obs.onCount || 0,
-            formattedValue: formatOccurrenceCount(t, obs.onCount || 0),
-          }));
-
-        return data.length > 0 ? data : [];
-      }
-
       const data = stats.targetCategory.observables
-        .filter((obs) => obs.onDuration > 0 || obs.onCount > 0)
+        .filter((obs) => obs.onCount > 0)
         .map((obs) => ({
           label: obs.observableName,
-          value: obs.onDuration || 0,
-          formattedValue: statistics.methods.formatDuration(obs.onDuration || 0),
+          value: obs.onCount || 0,
+          formattedValue: formatOccurrenceCount(t, obs.onCount || 0),
         }));
 
       return data.length > 0 ? data : [];


### PR DESCRIPTION
## Résumé

Suite de la PR #86. Dans l'onglet Statistiques > Mode avancé, l'histogramme affichait des **durées absolues** pour une catégorie continue, et des **occurrences** pour une catégorie ponctuelle. Or un histogramme compte des évènements par nature : il reste désormais **toujours en occurrences**, quel que soit le type de la catégorie cible.

- La répartition en **durée** reste portée par le **camembert**, toujours affiché uniquement pour les catégories continues — rien ne change de ce côté.
- L'histogramme, lui, affiche systématiquement le nombre d'occurrences par observable (titre "Nombre d'occurrences").
- Le libellé `barOnDurationTitle`, devenu inutilisé, a été retiré des fichiers de traduction FR/EN.

**Base de cette PR :** `fix/conditional-stats-occurrence-intro-label` (PR #86, pas encore mergée) — cette PR s'appuie dessus, à merger après (ou en même temps).

## Fichiers modifiés
- `front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue`
- `front/src/i18n/fr/index.ts`, `front/src/i18n/en-US/index.ts`

## Test plan
- [x] `yarn lint` (front) : passe
- [x] `vue-tsc --noEmit` : aucune nouvelle erreur sur le fichier modifié
- [ ] Vérification visuelle dans l'app avec une observation réelle (catégorie continue avec conditions) — à faire par Sylvain ou Valérie

🤖 Generated with [Claude Code](https://claude.com/claude-code)
