### PR TITLE
fix(statistics): graduations entieres sur l'axe Y des histogrammes d'occurrences

### DIFF
--- a/front/src/pages/userspace/statistics/_components/AmChartsBarChart.vue
+++ b/front/src/pages/userspace/statistics/_components/AmChartsBarChart.vue
@@ -138,8 +138,10 @@ export default defineComponent({
       );
 
       // Create Y axis (values) - pour barres verticales
+      // maxPrecision: 0 force des graduations entières (les valeurs sont des occurrences, jamais des fractions)
       const yAxis = chart.yAxes.push(
         am5xy.ValueAxis.new(root, {
+          maxPrecision: 0,
           renderer: am5xy.AxisRendererY.new(root, {}),
         })
       );


### PR DESCRIPTION
## Resume

Dans l'onglet Statistiques > Mode avance, l'axe Y de l'histogramme (diagramme en barres) pouvait afficher des graduations a virgule (ex: 0.5, 1.5) alors que les valeurs representees sont toujours des comptes d'occurrences, donc necessairement des nombres entiers.

## Changement

`AmChartsBarChart.vue` : ajout de `maxPrecision: 0` sur le `ValueAxis` (axe Y) pour forcer amCharts5 a ne calculer que des graduations entieres.

## Test

Modification ciblee d'une seule ligne de configuration d'axe, sans impact sur les donnees ou le reste de l'affichage.