### PR TITLE
fix(graph-customization): elargir le selecteur de couleur a 350px

### DIFF
--- a/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
+++ b/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
@@ -1147,7 +1147,10 @@ export default defineComponent({
 
 .color-picker-widget {
   display: block;
-  width: 320px;
+  // Quasar plafonne lui-même .q-color-picker a 350px (QColor.sass) ; en dessous,
+  // la rangee d'icones du pied (spectre/saisie/palette, alignees en "justify"
+  // sans padding) se retrouve trop serree.
+  width: 350px;
   max-width: 100%;
   margin: 0 auto;
 }


### PR DESCRIPTION
## Résumé

Corrige le bug rapporté : dans « Paramétrage des couleurs par observable », le popup « Choisir une couleur » affiche sa rangée d'icônes du pied (spectre / saisie manuelle / palette) trop à l'étroit, juste au-dessus des boutons Annuler/Valider.

**Cause racine** : `front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue` fixait la largeur du composant `q-color` de Quasar à `320px` via la classe `.color-picker-widget`. Quasar plafonne lui-même ce composant à `350px` (`QColor.sass`, `max-width: 350px`), et sa rangée d'icônes de pied (un `q-tabs` en `align: justify`, sans aucun padding) s'étire pour occuper toute la largeur disponible : en dessous de 350px, ces icônes se retrouvent mécaniquement compressées.

Remarque : signalé initialement sur un MacBook Pro M4 (macOS Tahoe), non reproduit ailleurs. Une largeur CSS fixe se calcule cependant de façon identique par Chromium quelle que soit la plateforme — il est probable que le problème soit universel mais simplement plus visible sur cet écran, ou pas remarqué ailleurs. Si les icônes s'affichaient comme du texte en toutes lettres plutôt que des pictogrammes sur cette machine, ce serait le signe d'un problème de chargement de police distinct, à vérifier séparément.

**Correctif** : largeur passée de 320px à 350px — le maximum que Quasar autorise pour ce composant.

Un composant dupliqué et inutilisé (`ItemColorPicker.vue`, jamais importé nulle part) contient exactement le même bug et la même CSS ; il n'a pas été touché ici (hors scope) mais mériterait d'être supprimé pour éviter toute confusion future.

## Test plan

- [x] `vue-tsc --noEmit` : 0 erreur
- [x] Vérifié hors-app avec le vrai composant Quasar `q-color` chargé en isolation (Vue + Quasar UMD) : chaque icône du pied passe de ~107px à ~117px de large (+9%), confirmant que la largeur de 350px est bien atteinte et correspond au maximum supporté par le composant
- [ ] Vérification manuelle dans l'appli Electron, idéalement sur le MacBook Pro M4 où le bug a été signalé : ouvrir le popup couleur depuis le panneau de paramétrage des couleurs, confirmer que les 3 icônes du pied s'affichent confortablement (et bien comme des pictogrammes, pas du texte)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
