### PR TITLE
fix(graph): coalescer les redessins protocole/relevés (instabilité du graphe)

### DIFF
--- a/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
+++ b/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
@@ -410,11 +410,19 @@ export default defineComponent({
       { immediate: false }
     );
 
-    // Sync structurel : setData+draw via requestRedraw (pas setProtocol+draw seuls).
-    // dataArea ne reconstruit readingsPerCategory que dans setData ; un draw
-    // après setProtocol seul laisse Y et data potentiellement désalignés.
+    // Sync structurel / rollback : full setData+draw (pas setProtocol+draw seuls).
     const syncGraphProtocol = () => {
       graph.requestRedraw();
+    };
+
+    /**
+     * Applique une mutation protocole purement visuelle sans déclencher le
+     * watch → scheduleRedraw (évite full setData 50 ms après redrawCategory).
+     */
+    const applyVisualProtocolUpdate = async (apply: () => void | Promise<void>) => {
+      await graph.runWithoutScheduledRedraw(async () => {
+        await apply();
+      });
     };
 
     let isRepairingPreferences = false;
@@ -634,39 +642,39 @@ export default defineComponent({
               ...category.graphPreferences,
               ...sanitizedPreference,
             };
-            
-            // Forcer la réactivité Vue en créant une nouvelle référence
-            protocol.sharedState.currentProtocol = {
-              ...currentProtocol,
-              _items: currentProtocol._items?.map((item) =>
-                item.id === categoryId ? category : item
-              ),
-            };
           }
 
-          // Attendre que Vue ait fini de mettre à jour les données réactives
-          // avant de mettre à jour le pixiApp et de redessiner
-          await nextTick();
-
-          // Mettre à jour le protocole dans le pixiApp APRÈS nextTick
-          // Cela garantit que les données sont à jour avant le redessinage
           const isStructuralCategoryChange =
             sanitizedPreference.displayMode !== undefined ||
             sanitizedPreference.supportCategoryId !== undefined;
 
-          if (graph.sharedState.pixiApp && protocol.sharedState.currentProtocol) {
-            if (isStructuralCategoryChange) {
-              // displayMode / supportCategoryId affectent l'axe Y et le layout :
-              // setData + draw (chemin unique), pas setProtocol + draw seuls.
+          if (isStructuralCategoryChange) {
+            // Affecte l'axe Y / layout : full setData+draw
+            protocol.sharedState.currentProtocol = {
+              ...currentProtocol,
+              _items: currentProtocol._items?.map((item) =>
+                item.id === categoryId && category ? category : item
+              ),
+            };
+            await nextTick();
+            graph.requestRedraw();
+          } else {
+            // Préférences visuelles : redraw ciblé, sans scheduleRedraw du watch
+            await applyVisualProtocolUpdate(async () => {
+              protocol.sharedState.currentProtocol = {
+                ...currentProtocol,
+                _items: currentProtocol._items?.map((item) =>
+                  item.id === categoryId && category ? category : item
+                ),
+              };
               await nextTick();
-              graph.requestRedraw();
-            } else {
-              graph.sharedState.pixiApp.setProtocol(
-                protocol.sharedState.currentProtocol as any
-              );
-              // Préférences visuelles : un seul redraw de la catégorie
-              graph.sharedState.pixiApp.redrawCategory(categoryId);
-            }
+              if (graph.sharedState.pixiApp && protocol.sharedState.currentProtocol) {
+                graph.sharedState.pixiApp.setProtocol(
+                  protocol.sharedState.currentProtocol as any
+                );
+                graph.sharedState.pixiApp.redrawCategory(categoryId);
+              }
+            });
           }
 
           // Mettre à jour via l'API (après le rendu pour ne pas bloquer l'UI)
@@ -693,23 +701,22 @@ export default defineComponent({
             );
           }
 
-          // Recharger le protocole depuis l'API pour garantir la persistance (bug 3.7)
+          // Recharger le protocole depuis l'API pour garantir la persistance (bug 3.7).
+          // L'assignation déclenche scheduleRedraw (un seul full sync post-persist).
           if (observation.sharedState.currentObservation) {
             const reloaded = await protocolService.findOneFromObservationId(
               observation.sharedState.currentObservation.id
             );
             protocol.sharedState.currentProtocol = reloaded;
-            if (graph.sharedState.pixiApp) {
-              // Rendu optimiste déjà effectué : synchroniser le protocole sans redraw.
-              graph.sharedState.pixiApp.setProtocol(reloaded as any);
-            }
             await repairStaleCategoryPreferences();
           }
 
           // Sauvegarder avec debounce
           methods.debouncedSave();
         } catch (error: any) {
-          protocol.sharedState.currentProtocol = originalProtocol;
+          await applyVisualProtocolUpdate(() => {
+            protocol.sharedState.currentProtocol = originalProtocol;
+          });
           syncGraphProtocol();
           
           const apiMessage = error?.response?.data?.message;
@@ -772,23 +779,24 @@ export default defineComponent({
           });
 
           if (updated && updatedItems) {
-            // Forcer la réactivité Vue en créant une nouvelle référence
-            protocol.sharedState.currentProtocol = {
-              ...currentProtocol,
-              _items: updatedItems,
-            };
-          }
-
-          await nextTick();
-
-          if (graph.sharedState.pixiApp && protocol.sharedState.currentProtocol) {
-            graph.sharedState.pixiApp.setProtocol(protocol.sharedState.currentProtocol as any);
-            graph.sharedState.pixiApp.updateObservablePreference(
-              observableId,
-              sanitizedPreference,
-              { redraw: false },
-            );
-            graph.sharedState.pixiApp.redrawObservable(observableId);
+            await applyVisualProtocolUpdate(async () => {
+              protocol.sharedState.currentProtocol = {
+                ...currentProtocol,
+                _items: updatedItems,
+              };
+              await nextTick();
+              if (graph.sharedState.pixiApp && protocol.sharedState.currentProtocol) {
+                graph.sharedState.pixiApp.setProtocol(
+                  protocol.sharedState.currentProtocol as any
+                );
+                graph.sharedState.pixiApp.updateObservablePreference(
+                  observableId,
+                  sanitizedPreference,
+                  { redraw: false },
+                );
+                graph.sharedState.pixiApp.redrawObservable(observableId);
+              }
+            });
           }
 
           // Mettre à jour via l'API
@@ -798,21 +806,20 @@ export default defineComponent({
             sanitizedPreference
           );
 
-          // Recharger le protocole depuis l'API pour garantir la persistance (bug 3.7)
+          // Recharger le protocole : l'assignation déclenche un seul scheduleRedraw.
           if (observation.sharedState.currentObservation) {
             const reloaded = await protocolService.findOneFromObservationId(
               observation.sharedState.currentObservation.id
             );
             protocol.sharedState.currentProtocol = reloaded;
-            if (graph.sharedState.pixiApp) {
-              graph.sharedState.pixiApp.setProtocol(reloaded as any);
-            }
           }
 
           // Sauvegarder avec debounce
           methods.debouncedSave();
         } catch (error: any) {
-          protocol.sharedState.currentProtocol = originalProtocol;
+          await applyVisualProtocolUpdate(() => {
+            protocol.sharedState.currentProtocol = originalProtocol;
+          });
           syncGraphProtocol();
           
           const apiMessage = error?.response?.data?.message;

--- a/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
+++ b/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
@@ -410,12 +410,11 @@ export default defineComponent({
       { immediate: false }
     );
 
-    const syncGraphProtocol = (protocolToSync: typeof protocol.sharedState.currentProtocol) => {
-      if (!graph.sharedState.pixiApp || !protocolToSync) {
-        return;
-      }
-      graph.sharedState.pixiApp.setProtocol(protocolToSync as any);
-      graph.sharedState.pixiApp.draw();
+    // Sync structurel : setData+draw via requestRedraw (pas setProtocol+draw seuls).
+    // dataArea ne reconstruit readingsPerCategory que dans setData ; un draw
+    // après setProtocol seul laisse Y et data potentiellement désalignés.
+    const syncGraphProtocol = () => {
+      graph.requestRedraw();
     };
 
     let isRepairingPreferences = false;
@@ -444,7 +443,7 @@ export default defineComponent({
             observation.sharedState.currentObservation.id
           );
           protocol.sharedState.currentProtocol = reloaded;
-          syncGraphProtocol(reloaded);
+          syncGraphProtocol();
         }
       } catch (error) {
         console.error('Failed to repair stale category graph preferences:', error);
@@ -651,20 +650,20 @@ export default defineComponent({
 
           // Mettre à jour le protocole dans le pixiApp APRÈS nextTick
           // Cela garantit que les données sont à jour avant le redessinage
-          if (graph.sharedState.pixiApp && protocol.sharedState.currentProtocol) {
-            graph.sharedState.pixiApp.setProtocol(protocol.sharedState.currentProtocol as any);
-          }
-
           const isStructuralCategoryChange =
             sanitizedPreference.displayMode !== undefined ||
             sanitizedPreference.supportCategoryId !== undefined;
 
-          if (graph.sharedState.pixiApp) {
+          if (graph.sharedState.pixiApp && protocol.sharedState.currentProtocol) {
             if (isStructuralCategoryChange) {
-              // displayMode / supportCategoryId affectent l'axe Y : redraw complet
+              // displayMode / supportCategoryId affectent l'axe Y et le layout :
+              // setData + draw (chemin unique), pas setProtocol + draw seuls.
               await nextTick();
-              await graph.sharedState.pixiApp.draw();
+              graph.requestRedraw();
             } else {
+              graph.sharedState.pixiApp.setProtocol(
+                protocol.sharedState.currentProtocol as any
+              );
               // Préférences visuelles : un seul redraw de la catégorie
               graph.sharedState.pixiApp.redrawCategory(categoryId);
             }
@@ -711,7 +710,7 @@ export default defineComponent({
           methods.debouncedSave();
         } catch (error: any) {
           protocol.sharedState.currentProtocol = originalProtocol;
-          syncGraphProtocol(originalProtocol);
+          syncGraphProtocol();
           
           const apiMessage = error?.response?.data?.message;
           const validationErrors = error?.response?.data?.errors;
@@ -814,7 +813,7 @@ export default defineComponent({
           methods.debouncedSave();
         } catch (error: any) {
           protocol.sharedState.currentProtocol = originalProtocol;
-          syncGraphProtocol(originalProtocol);
+          syncGraphProtocol();
           
           const apiMessage = error?.response?.data?.message;
           const validationErrors = error?.response?.data?.errors;

--- a/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
+++ b/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
@@ -140,6 +140,31 @@ export const useGraph = (options?: {
     const pixiApp = new PixiApp();
     sharedState.pixiApp = pixiApp;
 
+    // Le protocole et les relevés sont deux sources réactives distinctes,
+    // mises à jour de façon asynchrone et indépendante (chargement réseau,
+    // édition du protocole, etc.). Avec deux `watch` séparés déclenchant
+    // chacun un redessin immédiat, une mise à jour de l'une pouvait
+    // déclencher un rendu avec l'autre encore "en retard" (protocole neuf +
+    // relevés obsolètes, ou l'inverse) : le graphe affichait alors un état
+    // transitoire incohérent (catégories/étiquettes ne correspondant pas aux
+    // données, tracés absents) qui ne se corrigeait que si un second
+    // changement survenait juste après. On regroupe donc les deux
+    // déclencheurs derrière un court debounce : les changements rapprochés
+    // de protocole et de relevés sont coalescés en un seul redessin qui lit
+    // toujours l'état le plus récent des deux.
+    let scheduledRedrawId: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRedraw = (): void => {
+      if (!sharedState.ready || !sharedState.pixiApp) return;
+      if (scheduledRedrawId !== null) {
+        clearTimeout(scheduledRedrawId);
+      }
+      scheduledRedrawId = setTimeout(() => {
+        scheduledRedrawId = null;
+        if (!sharedState.ready || !sharedState.pixiApp) return;
+        void redrawFromObservation(sharedState.pixiApp);
+      }, 50);
+    };
+
     /**
      * Hook appelé lorsque le composant est monté dans le DOM.
      * À ce moment, le canvas est disponible et on peut initialiser PixiJS.
@@ -194,19 +219,13 @@ export const useGraph = (options?: {
      */
     watch(
       () => observation.readings?.sharedState?.currentReadings ?? [],
-      () => {
-        if (!sharedState.ready || !sharedState.pixiApp) return;
-        void redrawFromObservation(sharedState.pixiApp);
-      },
+      scheduleRedraw,
       { deep: true }
     );
 
     watch(
       () => observation.protocol?.sharedState?.currentProtocol,
-      () => {
-        if (!sharedState.ready || !sharedState.pixiApp) return;
-        void redrawFromObservation(sharedState.pixiApp);
-      },
+      scheduleRedraw,
       { deep: true }
     );
 
@@ -215,6 +234,10 @@ export const useGraph = (options?: {
      * On nettoie les ressources PixiJS pour éviter les fuites mémoire.
      */
     onUnmounted(() => {
+      if (scheduledRedrawId !== null) {
+        clearTimeout(scheduledRedrawId);
+        scheduledRedrawId = null;
+      }
       // Destruction de l'application PixiJS et libération des ressources
       pixiApp.destroy();
       sharedState.pixiApp = null;

--- a/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
+++ b/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
@@ -37,42 +37,41 @@ const sharedState = shallowReactive({
   } as IGraphRenderOptions,
 });
 
-/** Debounce partagé : Index (watches) et drawer (requestRedraw) coalescent ensemble. */
+/** Debounce partagé : Index (watches) et drawer coalescent ensemble. */
 let scheduledRedrawId: ReturnType<typeof setTimeout> | null = null;
 /** Invalide un setData/draw dépassé si un redraw plus récent a démarré. */
 let redrawGeneration = 0;
+/**
+ * Compteur de suppression : pendant un edit de préférence visuelle optimiste,
+ * l'assignation de currentProtocol ne doit pas enchaîner un full setData via
+ * le watch (sinon flicker + double travail avec redrawCategory/Observable).
+ */
+let scheduledRedrawSuppressionCount = 0;
+
+const clearScheduledRedraw = (): void => {
+  if (scheduledRedrawId !== null) {
+    clearTimeout(scheduledRedrawId);
+    scheduledRedrawId = null;
+  }
+};
 
 /**
  * Composable Vue pour gérer le graphique d'activité avec PixiJS.
  *
- * Ce composable encapsule toute la logique d'initialisation, de chargement des données
- * et de rendu du graphique. Il gère le cycle de vie de l'application PixiJS :
- * - Création lors du montage du composant
- * - Initialisation avec le canvas HTML
- * - Chargement des données d'observation
- * - Rendu du graphique
- * - Nettoyage lors du démontage
+ * Contrat de redraw :
+ * - Full (setData + draw) : chargement obs, relevés, protocole structurel, rollback, resize
+ * - Partiel (setProtocol + redrawCategory/Observable) : prefs visuelles optimistes,
+ *   enveloppées dans runWithoutScheduledRedraw pour ne pas déclencher le watch
  *
  * @param options - Options d'initialisation du graphique
  * @param options.init - Configuration d'initialisation
  * @param options.init.canvasRef - Référence Vue au canvas HTML qui sera utilisé par PixiJS
- *
- * @example
- * ```typescript
- * const canvasRef = ref<HTMLCanvasElement | null>(null);
- * const graph = useGraph({
- *   init: {
- *     canvasRef,
- *   },
- * });
- * ```
  */
 export const useGraph = (options?: {
   init?: {
     canvasRef: any;
   };
 }) => {
-  // Récupération du composable d'observation pour accéder aux données
   const observation = useObservation();
 
   /**
@@ -92,20 +91,26 @@ export const useGraph = (options?: {
     const protocol = observation.protocol?.sharedState?.currentProtocol ?? null;
     if (!protocol) return;
 
+    // Tout redraw immédiat (resize, requestRedraw, callback debounce) annule
+    // un éventuel timer concurrent pour éviter un second full redraw 50 ms plus tard.
+    clearScheduledRedraw();
+
     const generation = ++redrawGeneration;
 
     try {
       const normalizedReadings = normalizeReadingsForGraph(readings as IReading[]);
-      // Ne pas muter l'observation partagée : construire un payload local.
       pixiApp.setGraphRenderOptions(sharedState.graphRenderOptions, { redraw: false });
-      if (generation !== redrawGeneration) return;
+      if (generation !== redrawGeneration || sharedState.pixiApp !== pixiApp) return;
+
       pixiApp.setData({
         ...(obs as ICoreObservation),
         readings: normalizedReadings,
         protocol: protocol as unknown as ICoreObservation['protocol'],
       });
-      if (generation !== redrawGeneration) return;
+      if (generation !== redrawGeneration || sharedState.pixiApp !== pixiApp) return;
+
       await pixiApp.draw();
+      if (generation !== redrawGeneration || sharedState.pixiApp !== pixiApp) return;
     } catch (error) {
       // Guard rail: don't break the page on transient/partial data while editing.
       console.warn('Graph redraw skipped due to inconsistent data:', error);
@@ -118,14 +123,12 @@ export const useGraph = (options?: {
 
   /**
    * Planifie un redessin complet (setData + draw) après coalescence 50 ms.
-   * Utilisable depuis Index (watches) et depuis le drawer (sync structurel).
    */
   const scheduleRedraw = (): void => {
     if (!sharedState.ready || !sharedState.pixiApp) return;
     if (observation.sharedState.loading) return;
-    if (scheduledRedrawId !== null) {
-      clearTimeout(scheduledRedrawId);
-    }
+    if (scheduledRedrawSuppressionCount > 0) return;
+    clearScheduledRedraw();
     scheduledRedrawId = setTimeout(() => {
       scheduledRedrawId = null;
       if (!sharedState.ready || !sharedState.pixiApp) return;
@@ -140,11 +143,22 @@ export const useGraph = (options?: {
   const requestRedraw = (): void => {
     if (!sharedState.ready || !sharedState.pixiApp) return;
     if (observation.sharedState.loading) return;
-    if (scheduledRedrawId !== null) {
-      clearTimeout(scheduledRedrawId);
-      scheduledRedrawId = null;
-    }
     void redrawFromObservation(sharedState.pixiApp);
+  };
+
+  /**
+   * Exécute `fn` sans qu'une assignation protocole/relevés ne planifie de full redraw.
+   * À utiliser autour des updates optimistes purement visuels (couleur, motif, etc.).
+   */
+  const runWithoutScheduledRedraw = async (
+    fn: () => void | Promise<void>,
+  ): Promise<void> => {
+    scheduledRedrawSuppressionCount += 1;
+    try {
+      await fn();
+    } finally {
+      scheduledRedrawSuppressionCount -= 1;
+    }
   };
 
   /**
@@ -185,29 +199,16 @@ export const useGraph = (options?: {
 
   // Si des options d'initialisation sont fournies, créer et initialiser PixiApp
   if (options?.init) {
-    // Création de l'instance PixiApp qui gère tout le rendu graphique
     const pixiApp = new PixiApp();
     sharedState.pixiApp = pixiApp;
 
     // Enchaînement `_loadObservation` :
     //   loading=true → obs=null → readings=[] → protocol=null
     //   → await loadReadings → await loadProtocol → obs=… → loading=false
-    // Pendant le chargement, les watches relevés/protocole voient des états
-    // partiels (et `redrawFromObservation` early-return faute d'obs). À la fin,
-    // seul `loading` / l'id d'observation signalent que le triplet est prêt :
-    // sans les watches ci-dessous, le graphe ne se redessinait jamais après un
-    // rechargement si le composant était déjà monté.
-    //
-    // Hors chargement, protocole et relevés peuvent encore bouger de façon
-    // rapprochée (édition, sync inter-fenêtres). Un court debounce coalesce
-    // ces bursts en un seul redessin qui lit l'état le plus récent des deux.
+    // Pendant le chargement, les watches early-return. À la fin, loading/id
+    // déclenchent le seul redessin cohérent du triplet.
 
-    /**
-     * Hook appelé lorsque le composant est monté dans le DOM.
-     * À ce moment, le canvas est disponible et on peut initialiser PixiJS.
-     */
     onMounted(async () => {
-      // Validation des options d'initialisation
       if (!options.init) {
         throw new Error('No init options provided');
       }
@@ -216,42 +217,32 @@ export const useGraph = (options?: {
         throw new Error('No canvasRef provided');
       }
 
-      // overlay actif jusqu'au premier rendu : masque le buffer GPU noir
       sharedState.loading = true;
       sharedState.ready = false;
 
       try {
-        // Initialisation de l'application PixiJS avec le canvas HTML
-        // Le canvas sera utilisé pour le rendu WebGL
         await pixiApp.init({
           view: options.init.canvasRef.value.canvasRef,
         });
 
-        // À partir d'ici le renderer et les axes existent : les redraws sont sûrs.
         sharedState.ready = true;
 
-        // Récupération de l'observation courante depuis le composable
         await redrawFromObservation(pixiApp);
 
         console.info('Pixi app initialized');
 
-        // On garde l'overlay jusqu'à ce qu'une frame ait réellement été peinte,
-        // sinon le canvas WebGL (buffer non initialisé = noir) reste visible
-        // pendant le tout premier rendu. Deux rAF = au moins une frame composée.
         await new Promise<void>((resolve) =>
           requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
         );
       } catch (error) {
         console.error('Failed to initialize Pixi app:', error);
       } finally {
-        // masque l'overlay une fois la première frame peinte (ou en cas d'échec)
         sharedState.loading = false;
       }
     });
 
     useAppResume(refreshGraph);
 
-    // Fin de chargement : le moment où obs + protocole + relevés sont cohérents.
     watch(
       () => observation.sharedState.loading,
       (loading) => {
@@ -259,15 +250,11 @@ export const useGraph = (options?: {
       }
     );
 
-    // Changement de chronique (y compris obs qui apparaît après hydratation).
     watch(
       () => observation.sharedState.currentObservation?.id,
       () => scheduleRedraw()
     );
 
-    /**
-     * Watch pour rafraîchir le graphe quand les relevés changent (bug 3.4 : horodatage modifié)
-     */
     watch(
       () => observation.readings?.sharedState?.currentReadings ?? [],
       scheduleRedraw,
@@ -280,17 +267,9 @@ export const useGraph = (options?: {
       { deep: true }
     );
 
-    /**
-     * Hook appelé lorsque le composant est démonté du DOM.
-     * On nettoie les ressources PixiJS pour éviter les fuites mémoire.
-     */
     onUnmounted(() => {
-      if (scheduledRedrawId !== null) {
-        clearTimeout(scheduledRedrawId);
-        scheduledRedrawId = null;
-      }
+      clearScheduledRedraw();
       redrawGeneration += 1;
-      // Destruction de l'application PixiJS et libération des ressources
       pixiApp.destroy();
       sharedState.pixiApp = null;
       sharedState.ready = false;
@@ -302,9 +281,11 @@ export const useGraph = (options?: {
     sharedState,
     onCanvasResize,
     setTimeDisplayFormat,
-    /** Redessin complet immédiat (setData + draw). Préférer aux setProtocol/draw isolés. */
+    /** Redessin complet immédiat (setData + draw). */
     requestRedraw,
     /** Redessin complet coalescé (50 ms). */
     scheduleRedraw,
+    /** Coupe le scheduleRedraw pendant un update optimiste purement visuel. */
+    runWithoutScheduledRedraw,
   };
 };

--- a/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
+++ b/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
@@ -5,7 +5,7 @@ import { DEFAULT_GRAPH_RENDER_OPTIONS, TimeDisplayFormatEnum } from '@actograph/
 import { useObservation } from 'src/composables/use-observation';
 import { useAppResume } from 'src/composables/use-app-resume';
 import { isElementVisible } from 'src/utils/dom.utils';
-import { IObservation, IProtocol, IReading } from '@services/observations/interface';
+import { IObservation, IReading } from '@services/observations/interface';
 import type { IObservation as ICoreObservation, IReading as ICoreReading } from '@actograph/core';
 
 /** API may deserialize dateTime as string; normalize before graph helpers. */
@@ -37,9 +37,14 @@ const sharedState = shallowReactive({
   } as IGraphRenderOptions,
 });
 
+/** Debounce partagé : Index (watches) et drawer (requestRedraw) coalescent ensemble. */
+let scheduledRedrawId: ReturnType<typeof setTimeout> | null = null;
+/** Invalide un setData/draw dépassé si un redraw plus récent a démarré. */
+let redrawGeneration = 0;
+
 /**
  * Composable Vue pour gérer le graphique d'activité avec PixiJS.
- * 
+ *
  * Ce composable encapsule toute la logique d'initialisation, de chargement des données
  * et de rendu du graphique. Il gère le cycle de vie de l'application PixiJS :
  * - Création lors du montage du composant
@@ -47,11 +52,11 @@ const sharedState = shallowReactive({
  * - Chargement des données d'observation
  * - Rendu du graphique
  * - Nettoyage lors du démontage
- * 
+ *
  * @param options - Options d'initialisation du graphique
  * @param options.init - Configuration d'initialisation
  * @param options.init.canvasRef - Référence Vue au canvas HTML qui sera utilisé par PixiJS
- * 
+ *
  * @example
  * ```typescript
  * const canvasRef = ref<HTMLCanvasElement | null>(null);
@@ -70,6 +75,11 @@ export const useGraph = (options?: {
   // Récupération du composable d'observation pour accéder aux données
   const observation = useObservation();
 
+  /**
+   * Chemin unique de rendu cohérent : lit obs + protocole + relevés courants,
+   * puis setData + draw. Ne pas appeler setProtocol/draw seuls pour un sync
+   * structurel : dataArea ne reconstruit readingsPerCategory que dans setData.
+   */
   const redrawFromObservation = async (pixiApp: PixiApp): Promise<void> => {
     // Pendant `_loadObservation`, relevés puis protocole sont hydratés alors que
     // `currentObservation` est encore null ; un rendu partiel serait incohérent.
@@ -82,15 +92,19 @@ export const useGraph = (options?: {
     const protocol = observation.protocol?.sharedState?.currentProtocol ?? null;
     if (!protocol) return;
 
+    const generation = ++redrawGeneration;
+
     try {
       const normalizedReadings = normalizeReadingsForGraph(readings as IReading[]);
-      obs.readings = normalizedReadings as IReading[];
-      obs.protocol = protocol as IProtocol;
+      // Ne pas muter l'observation partagée : construire un payload local.
       pixiApp.setGraphRenderOptions(sharedState.graphRenderOptions, { redraw: false });
+      if (generation !== redrawGeneration) return;
       pixiApp.setData({
         ...(obs as ICoreObservation),
         readings: normalizedReadings,
+        protocol: protocol as unknown as ICoreObservation['protocol'],
       });
+      if (generation !== redrawGeneration) return;
       await pixiApp.draw();
     } catch (error) {
       // Guard rail: don't break the page on transient/partial data while editing.
@@ -100,6 +114,37 @@ export const useGraph = (options?: {
 
   const getCanvasElement = (): HTMLCanvasElement | null => {
     return options?.init?.canvasRef?.value?.canvasRef ?? null;
+  };
+
+  /**
+   * Planifie un redessin complet (setData + draw) après coalescence 50 ms.
+   * Utilisable depuis Index (watches) et depuis le drawer (sync structurel).
+   */
+  const scheduleRedraw = (): void => {
+    if (!sharedState.ready || !sharedState.pixiApp) return;
+    if (observation.sharedState.loading) return;
+    if (scheduledRedrawId !== null) {
+      clearTimeout(scheduledRedrawId);
+    }
+    scheduledRedrawId = setTimeout(() => {
+      scheduledRedrawId = null;
+      if (!sharedState.ready || !sharedState.pixiApp) return;
+      if (observation.sharedState.loading) return;
+      void redrawFromObservation(sharedState.pixiApp);
+    }, 50);
+  };
+
+  /**
+   * Redessin complet immédiat (bypass debounce) — rollback / sync structurel.
+   */
+  const requestRedraw = (): void => {
+    if (!sharedState.ready || !sharedState.pixiApp) return;
+    if (observation.sharedState.loading) return;
+    if (scheduledRedrawId !== null) {
+      clearTimeout(scheduledRedrawId);
+      scheduledRedrawId = null;
+    }
+    void redrawFromObservation(sharedState.pixiApp);
   };
 
   /**
@@ -156,20 +201,6 @@ export const useGraph = (options?: {
     // Hors chargement, protocole et relevés peuvent encore bouger de façon
     // rapprochée (édition, sync inter-fenêtres). Un court debounce coalesce
     // ces bursts en un seul redessin qui lit l'état le plus récent des deux.
-    let scheduledRedrawId: ReturnType<typeof setTimeout> | null = null;
-    const scheduleRedraw = (): void => {
-      if (!sharedState.ready || !sharedState.pixiApp) return;
-      if (observation.sharedState.loading) return;
-      if (scheduledRedrawId !== null) {
-        clearTimeout(scheduledRedrawId);
-      }
-      scheduledRedrawId = setTimeout(() => {
-        scheduledRedrawId = null;
-        if (!sharedState.ready || !sharedState.pixiApp) return;
-        if (observation.sharedState.loading) return;
-        void redrawFromObservation(sharedState.pixiApp);
-      }, 50);
-    };
 
     /**
      * Hook appelé lorsque le composant est monté dans le DOM.
@@ -258,6 +289,7 @@ export const useGraph = (options?: {
         clearTimeout(scheduledRedrawId);
         scheduledRedrawId = null;
       }
+      redrawGeneration += 1;
       // Destruction de l'application PixiJS et libération des ressources
       pixiApp.destroy();
       sharedState.pixiApp = null;
@@ -270,5 +302,9 @@ export const useGraph = (options?: {
     sharedState,
     onCanvasResize,
     setTimeDisplayFormat,
+    /** Redessin complet immédiat (setData + draw). Préférer aux setProtocol/draw isolés. */
+    requestRedraw,
+    /** Redessin complet coalescé (50 ms). */
+    scheduleRedraw,
   };
-}
+};

--- a/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
+++ b/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
@@ -71,6 +71,10 @@ export const useGraph = (options?: {
   const observation = useObservation();
 
   const redrawFromObservation = async (pixiApp: PixiApp): Promise<void> => {
+    // Pendant `_loadObservation`, relevés puis protocole sont hydratés alors que
+    // `currentObservation` est encore null ; un rendu partiel serait incohérent.
+    if (observation.sharedState.loading) return;
+
     const obs = observation.sharedState.currentObservation as IObservation;
     if (!obs) return;
 
@@ -140,27 +144,29 @@ export const useGraph = (options?: {
     const pixiApp = new PixiApp();
     sharedState.pixiApp = pixiApp;
 
-    // Le protocole et les relevés sont deux sources réactives distinctes,
-    // mises à jour de façon asynchrone et indépendante (chargement réseau,
-    // édition du protocole, etc.). Avec deux `watch` séparés déclenchant
-    // chacun un redessin immédiat, une mise à jour de l'une pouvait
-    // déclencher un rendu avec l'autre encore "en retard" (protocole neuf +
-    // relevés obsolètes, ou l'inverse) : le graphe affichait alors un état
-    // transitoire incohérent (catégories/étiquettes ne correspondant pas aux
-    // données, tracés absents) qui ne se corrigeait que si un second
-    // changement survenait juste après. On regroupe donc les deux
-    // déclencheurs derrière un court debounce : les changements rapprochés
-    // de protocole et de relevés sont coalescés en un seul redessin qui lit
-    // toujours l'état le plus récent des deux.
+    // Enchaînement `_loadObservation` :
+    //   loading=true → obs=null → readings=[] → protocol=null
+    //   → await loadReadings → await loadProtocol → obs=… → loading=false
+    // Pendant le chargement, les watches relevés/protocole voient des états
+    // partiels (et `redrawFromObservation` early-return faute d'obs). À la fin,
+    // seul `loading` / l'id d'observation signalent que le triplet est prêt :
+    // sans les watches ci-dessous, le graphe ne se redessinait jamais après un
+    // rechargement si le composant était déjà monté.
+    //
+    // Hors chargement, protocole et relevés peuvent encore bouger de façon
+    // rapprochée (édition, sync inter-fenêtres). Un court debounce coalesce
+    // ces bursts en un seul redessin qui lit l'état le plus récent des deux.
     let scheduledRedrawId: ReturnType<typeof setTimeout> | null = null;
     const scheduleRedraw = (): void => {
       if (!sharedState.ready || !sharedState.pixiApp) return;
+      if (observation.sharedState.loading) return;
       if (scheduledRedrawId !== null) {
         clearTimeout(scheduledRedrawId);
       }
       scheduledRedrawId = setTimeout(() => {
         scheduledRedrawId = null;
         if (!sharedState.ready || !sharedState.pixiApp) return;
+        if (observation.sharedState.loading) return;
         void redrawFromObservation(sharedState.pixiApp);
       }, 50);
     };
@@ -213,6 +219,20 @@ export const useGraph = (options?: {
     });
 
     useAppResume(refreshGraph);
+
+    // Fin de chargement : le moment où obs + protocole + relevés sont cohérents.
+    watch(
+      () => observation.sharedState.loading,
+      (loading) => {
+        if (!loading) scheduleRedraw();
+      }
+    );
+
+    // Changement de chronique (y compris obs qui apparaît après hydratation).
+    watch(
+      () => observation.sharedState.currentObservation?.id,
+      () => scheduleRedraw()
+    );
 
     /**
      * Watch pour rafraîchir le graphe quand les relevés changent (bug 3.4 : horodatage modifié)

--- a/packages/graph/src/pixi-app/index.ts
+++ b/packages/graph/src/pixi-app/index.ts
@@ -432,6 +432,12 @@ export class PixiApp {
   }
 
   private async executeDraw() {
+    // destroy() peut avoir annulé le rAF ; si executeDraw était déjà entré,
+    // on sort avant de toucher plot/axes détruits.
+    if (!this.isInitialized) {
+      return;
+    }
+
     this.plot.x = 0;
     this.plot.y = 0;
     this.plot.scale.set(1);
@@ -928,7 +934,20 @@ export class PixiApp {
 
   public destroy() {
     this.isInitialized = false;
+
+    if (this.drawRafId !== null) {
+      cancelAnimationFrame(this.drawRafId);
+      this.drawRafId = null;
+    }
+    const pendingResolvers = this.drawResolvers;
+    this.drawResolvers = [];
+    pendingResolvers.forEach((resolve) => resolve());
+
     this.teardownContextHandlers?.();
+
+    if (this.dataArea) {
+      this.dataArea.clearHoverOverlay();
+    }
 
     if (this.app.canvas && (this.app.canvas as any)._zoomPanHandlers) {
       const handlers = (this.app.canvas as any)._zoomPanHandlers;


### PR DESCRIPTION
## Contexte

Plusieurs bêta-testeuses ont signalé (voir `rapport-bug-instabilite-graphe-pour-sylvain-2026-07-17.md`) un affichage instable/incohérent du graphe d'activité, sous 3 formes observées le 17 juillet :
1. Étiquette d'observable affichée en très grand format, mal positionnée, déclenchée par le survol de la souris entre le graphe et le panneau de personnalisation.
2. Graphe incorrect dès l'ouverture (sans interaction), avec un axe qui semble tronqué par rapport aux étiquettes.
3. Axes présents mais aucune donnée tracée, catégories affichées incomplètes/différentes du protocole réel.

Ce rapport fait suite (et complète) le point A3 du 11 juillet, dont la correction précédente (boucle `ResizeObserver` / splitter) est déjà en place mais n'empêche pas ces nouveaux symptômes.

## Diagnostic (enchaînements)

### Cause principale corrigée ici

Dans `_loadObservation`, l'ordre réel est :

```
loading=true → obs=null → readings=[] → protocol=null
→ await loadReadings → await loadProtocol → obs=… → loading=false
```

Pendant ce chargement, les watches relevés/protocole voient des états partiels, et `redrawFromObservation` early-return faute d'observation. **À la fin, rien ne watchait `loading` ni `currentObservation.id`** : si le graphe était déjà monté, il ne se redessinait pas (ou restait sur un état stale), ce qui explique notamment les symptômes 2 et 3.

Un simple debounce de 50 ms sur protocole/relevés ne corrigeait **pas** cet enchaînement : les mises à jour pendant le load sont volontairement ignorées (pas d'obs), et le signal utile est la fin de `loading`.

### Correctif

1. Ignorer les redessins tant que `observation.sharedState.loading` est vrai
2. Watcher `loading → false` et `currentObservation.id` pour redessiner une fois le triplet cohérent
3. Conserver le debounce 50 ms sur relevés/protocole pour coalescer les bursts hors chargement (édition, sync inter-fenêtres)

### Hors scope de cette PR

Le symptôme 1 (étiquette géante au survol graphe ↔ panneau) ressemble davantage à une régression/résidu de layout type A3 (splitter / chaîne de hauteur / hover) qu'à un désync protocole/relevés. À traiter séparément si toujours reproductible après ce fix.

## Limites / à vérifier avant merge

- Tester : ouvrir une chronique avec beaucoup d'observables, basculer de chronique pendant que la page Analyse est déjà ouverte, éditer le protocole puis revenir au graphe.
- Si le debounce de 50 ms s'avère insuffisant ou trop perceptible, il peut être ajusté (une seule constante dans `use-graph.ts`).
- `vue-tsc --noEmit` passe.