### PR TITLE
fix: dernier état non affiché en mode Frise/Fond avant le Stop

### DIFF
--- a/packages/graph/src/__tests__/continuous-segments.utils.test.ts
+++ b/packages/graph/src/__tests__/continuous-segments.utils.test.ts
@@ -188,7 +188,7 @@ describe('continuous-segments.utils', () => {
       expect(pairs[0]?.to.dateTime).toEqual(new Date('2024-01-01T10:30:00Z'));
     });
 
-    it('pairs consecutive DATA within the same segment only', () => {
+    it('pairs consecutive DATA within the same segment only, and extends the last DATA to the STOP', () => {
       const readings = [
         mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:10:00Z') }),
         mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:15:00Z') }),
@@ -198,8 +198,35 @@ describe('continuous-segments.utils', () => {
 
       const pairs = iterContinuousDataPairs(readings);
 
+      expect(pairs).toHaveLength(2);
+      expect(pairs[0]?.from.dateTime).toEqual(new Date('2024-01-01T10:10:00Z'));
+      expect(pairs[0]?.to.dateTime).toEqual(new Date('2024-01-01T10:15:00Z'));
+      expect(pairs[1]?.from.dateTime).toEqual(new Date('2024-01-01T10:15:00Z'));
+      expect(pairs[1]?.to.dateTime).toEqual(new Date('2024-01-01T10:30:00Z'));
+    });
+
+    it('extends a single DATA reading to the closing STOP (last state before chronicle end)', () => {
+      const readings = [
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:10:00Z') }),
+        mk({ type: ReadingTypeEnum.STOP, dateTime: new Date('2024-01-01T10:30:00Z') }),
+      ];
+
+      const pairs = iterContinuousDataPairs(readings);
+
       expect(pairs).toHaveLength(1);
       expect(pairs[0]?.from.dateTime).toEqual(new Date('2024-01-01T10:10:00Z'));
+      expect(pairs[0]?.to.dateTime).toEqual(new Date('2024-01-01T10:30:00Z'));
+    });
+
+    it('does not extend when the segment has no closing STOP (recording still in progress)', () => {
+      const readings = [
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:10:00Z') }),
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:15:00Z') }),
+      ];
+
+      const pairs = iterContinuousDataPairs(readings);
+
+      expect(pairs).toHaveLength(1);
       expect(pairs[0]?.to.dateTime).toEqual(new Date('2024-01-01T10:15:00Z'));
     });
   });

--- a/packages/graph/src/utils/continuous-segments.utils.ts
+++ b/packages/graph/src/utils/continuous-segments.utils.ts
@@ -109,6 +109,10 @@ export function getContinuousSegmentStartIndices(readings: IReading[]): number[]
  * Consecutive DATA pairs within the same continuous segment (no bridge across
  * STOP). Pauses are ignored and do not break pairing. Used for background and
  * frieze rendering.
+ *
+ * The last DATA of a segment is also paired with the segment's closing STOP
+ * (session end or pause), so the final state is drawn through to that
+ * boundary instead of disappearing.
  */
 export function iterContinuousDataPairs(
   readings: IReading[],
@@ -119,12 +123,21 @@ export function iterContinuousDataPairs(
   for (let s = 0; s < starts.length; s++) {
     const segmentStartIdx = starts[s]!;
     const segmentEndIdx = s + 1 < starts.length ? starts[s + 1]! : readings.length;
-    const dataInSegment = readings
-      .slice(segmentStartIdx, segmentEndIdx)
-      .filter((reading) => reading.type === ReadingTypeEnum.DATA);
+    const segmentReadings = readings.slice(segmentStartIdx, segmentEndIdx);
+    const dataInSegment = segmentReadings.filter(
+      (reading) => reading.type === ReadingTypeEnum.DATA,
+    );
 
     for (let i = 0; i < dataInSegment.length - 1; i++) {
       pairs.push({ from: dataInSegment[i]!, to: dataInSegment[i + 1]! });
+    }
+
+    const lastData = dataInSegment[dataInSegment.length - 1];
+    const boundary = [...segmentReadings]
+      .reverse()
+      .find((reading) => reading.type === ReadingTypeEnum.STOP);
+    if (lastData && boundary) {
+      pairs.push({ from: lastData, to: boundary });
     }
   }
 


### PR DESCRIPTION
## Résumé
- En mode Frise (et en mode Fond) du graphe, le dernier état d'une catégorie ne s'affichait pas jusqu'au Stop (fin de chronique). `iterContinuousDataPairs` ne reliait que les DATA consécutifs entre eux, sans jamais relier la dernière DATA d'un segment au marqueur STOP qui le clôture.
- Le mode Normal (traits) affichait correctement le dernier état jusqu'au Stop, ce qui rendait l'écart visible entre les deux modes (cf. captures jointes au rapport).
- Correction : `iterContinuousDataPairs` ajoute désormais une paire finale (dernière DATA -> STOP) quand le segment se termine par un Stop. Sans Stop (enregistrement en cours), aucun changement de comportement.
- Vérifié que les pauses (PAUSE_START/PAUSE_END) n'entrent jamais dans les données passées à cette fonction dans le pipeline réel (`setData` ne pousse que les DATA, seule la fusion ajoute les STOP) : aucun impact sur le comportement pendant une pause.

## Test plan
- [x] Tests unitaires mis à jour/ajoutés dans `continuous-segments.utils.test.ts` (segment avec Stop, DATA unique + Stop, pas de Stop)
- [x] Vérification manuelle de la logique via script ts-node (jest indisponible dans cet environnement, dépendances de test non installées pour ce package)
- [x] `tsc --noEmit` sans erreur sur le package `graph`
- [ ] Vérification visuelle dans l'appli par Sylvain recommandée avant merge