### PR TITLE
fix: réinitialiser l'état du chronomètre au chargement d'une observation

### DIFF
--- a/front/src/composables/use-observation/index.ts
+++ b/front/src/composables/use-observation/index.ts
@@ -321,6 +321,20 @@ export const useObservation = (options?: { init?: boolean }) => {
       readings.sharedState.currentReadings = [];
       protocol.sharedState.currentProtocol = null;
 
+      // sharedState est un singleton partagé par toute l'appli : sans ce reset,
+      // currentDate/elapsedTime/startTime d'une précédente observation en mode
+      // chronomètre (basée sur CHRONOMETER_T0, 9 février 1989) fuitent vers
+      // l'observation qu'on charge ici (ex: une chronique dupliquée), qui les
+      // réutilise ensuite via le fallback `currentDate || new Date()`.
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+      sharedState.isPlaying = false;
+      sharedState.elapsedTime = 0;
+      sharedState.startTime = null;
+      sharedState.currentDate = null;
+
       try {
         await readings.methods.loadReadings(observation);
         await protocol.methods.loadProtocol(observation);


### PR DESCRIPTION
## Bug

Quand une chronique en mode **chronomètre** avait été jouée ou mise en pause, puis qu'on ouvrait/chargeait une autre chronique (typiquement une chronique dupliquée) et qu'on la basculait en mode **calendrier**, celle-ci se retrouvait avec une date figée au **09 février 1989**.

## Cause

`09/02/1989` n'est pas un artefact d'epoch : c'est `CHRONOMETER_T0`, la constante "point zéro" du mode chronomètre (`front/src/utils/chronometer.constants.ts`). En mode chronomètre, chaque relevé est daté `t0 + durée écoulée`.

`currentDate` / `elapsedTime` / `startTime` / `isPlaying` vivent dans un état **singleton partagé par toute l'application** (`sharedState` dans `use-observation/index.ts`), pas par chronique. `_loadObservation` réinitialisait `currentObservation`, `currentReadings` et `currentProtocol`, mais oubliait ces quatre champs.

Résultat : la date `1989` laissée par une session chronomètre précédente fuitait vers la chronique suivante. En mode calendrier, la création d'un relevé utilise `currentDate || new Date()` (`use-readings.ts`) — un fallback qui ne se déclenche que si `currentDate` est `null`, pas s'il contient encore l'ancienne valeur de 1989.

## Correctif

Réinitialise `isPlaying`, `elapsedTime`, `startTime`, `currentDate` (et l'intervalle du timer) dans `_loadObservation`, au même endroit où `currentReadings`/`currentProtocol` sont déjà remis à zéro — donc à chaque chargement d'observation, y compris une chronique dupliquée.

## Test plan — vérifié de bout en bout

Environnement de dev complet lancé (API NestJS + SQLite + frontend Quasar), scénario reproduit avec preuve avant/après :

**Sans le correctif** (code temporairement retiré pour la démonstration) :
1. Chronique A en mode chronomètre jouée puis mise en pause → résidu de date interne créé (`sharedState.currentDate` ancré sur `CHRONOMETER_T0`)
2. Chargement d'une chronique B → elle hérite visiblement du résidu (le compteur affichait déjà `00:00:10.230` avant même d'avoir démarré)
3. Bascule de B en mode calendrier + création d'un relevé → `dateTime: "1989-02-09T00:00:20.462Z"` en base — **bug reproduit à l'identique du signalement**.

**Avec le correctif restauré**, exactement les mêmes étapes :
- La chronique B nouvellement chargée repart à `00:00:00.000` (pas de résidu)
- Le relevé créé après bascule en calendrier obtient `dateTime: "2026-07-20T09:58:22.100Z"` en base — la date du jour, comme attendu.

Le fichier a ensuite été remis dans l'état exact du commit (diff vide), les chroniques de test supprimées.

- [x] `yarn lint` (frontend) — clean
- [x] Repro manuelle bout en bout (API + frontend) : bug reproduit sans le fix, corrigé avec le fix

🤖 Généré avec [Claude Code](https://claude.com/claude-code)
