### PR TITLE
fix(dialogs): empecher le debordement horizontal des boites de dialogue

### DIFF
--- a/front/lib-improba/components/app/modals/DDialogCard.vue
+++ b/front/lib-improba/components/app/modals/DDialogCard.vue
@@ -120,23 +120,25 @@ export default defineComponent({
   // q-dialog__inner) pour que le dialogue puisse toujours retrecir.
   &--sm {
     min-width: min(400px, calc(100vw - 48px));
-    max-width: 90vw;
+    max-width: min(90vw, calc(100vw - 48px));
   }
 
   &--md {
     min-width: min(500px, calc(100vw - 48px));
-    max-width: 700px;
+    // Sans plafond viewport, un contenu large (max 700px) deborde encore
+    // sur fenetre etroite : on aligne max-width sur la meme contrainte.
+    max-width: min(700px, calc(100vw - 48px));
   }
 
   &--lg {
     width: 600px;
-    max-width: 90vw;
+    max-width: min(90vw, calc(100vw - 48px));
     max-height: 80vh;
   }
 
   &--xl {
     min-width: min(700px, calc(100vw - 48px));
-    max-width: 900px;
+    max-width: min(900px, calc(100vw - 48px));
   }
 
   &--wide {

--- a/front/lib-improba/components/app/modals/DDialogCard.vue
+++ b/front/lib-improba/components/app/modals/DDialogCard.vue
@@ -89,6 +89,12 @@ export default defineComponent({
 <style lang="scss">
 .d-dialog-card {
   .q-card {
+    // Sans largeur explicite, la carte se dimensionne sur le contenu le
+    // plus large (ex. le champ "Catégorie de destination") au lieu de se
+    // limiter a son parent flex (.d-dialog-card), qui lui est bien
+    // contraint a la largeur de la fenetre. Le pied de page (boutons
+    // Annuler/Valider) deborde alors hors champ, invisible sans defiler.
+    width: 100%;
     border: 1px solid var(--neutral-low);
     border-radius: 12px;
     box-shadow: 0 16px 36px var(--neutral-high-20);
@@ -104,13 +110,21 @@ export default defineComponent({
     padding-top: 16px;
   }
 
+  // Le min-width est un plancher fixe : si la fenetre de l'appli est plus
+  // etroite que ce plancher (fenetre redimensionnee, petit ecran), il entre
+  // en conflit avec max-width et le q-dialog__inner (overflow: auto) affiche
+  // une barre de defilement horizontale au lieu de retrecir le dialogue.
+  // Le pied de page (boutons Annuler/Valider) se retrouve alors hors champ,
+  // obligeant a faire defiler le dialogue pour l'atteindre. On plafonne donc
+  // le min-width a la largeur de fenetre disponible (moins le padding du
+  // q-dialog__inner) pour que le dialogue puisse toujours retrecir.
   &--sm {
-    min-width: 400px;
+    min-width: min(400px, calc(100vw - 48px));
     max-width: 90vw;
   }
 
   &--md {
-    min-width: 500px;
+    min-width: min(500px, calc(100vw - 48px));
     max-width: 700px;
   }
 
@@ -121,7 +135,7 @@ export default defineComponent({
   }
 
   &--xl {
-    min-width: 700px;
+    min-width: min(700px, calc(100vw - 48px));
     max-width: 900px;
   }
 


### PR DESCRIPTION
## Contexte

Retour bêta-testeuse (Chapitre I #7 — Duplication et déplacement) : dans la boîte "Déplacer vers une autre catégorie", le bouton "Déplacer" pouvait se retrouver hors champ, obligeant à déplacer la fenêtre de l'appli pour l'atteindre.

## Cause

En reproduisant le bug (fenêtre réduite), deux problèmes cumulés dans `DDialogCard.vue` :

- Le `.q-card` interne n'avait pas de largeur explicite : il se dimensionnait sur son contenu le plus large au lieu de se limiter à son parent `.d-dialog-card` (qui, lui, était déjà borné à la largeur de la fenêtre). Le pied de page (boutons Annuler/Valider) débordait alors hors champ.
- Le `min-width` fixe des tailles de dialogue (sm/md/xl) entrait en conflit avec `max-width` sur une fenêtre étroite, provoquant un défilement au lieu d'un rétrécissement du dialogue.

## Correctif

- `width: 100%` sur `.q-card` pour qu'il suive toujours la largeur de son conteneur.
- `min-width` des tailles sm/md/xl plafonné à la largeur de fenêtre disponible via `min(Npx, calc(100vw - 48px))`.

## Vérification

Testé en local (fenêtre réduite à 380-420px) :
- Boîte "Déplacer vers une autre catégorie" (taille sm) : les deux boutons restent visibles et cliquables.
- Boîte "Ajouter une catégorie" (taille sm) et boîte d'aide (taille md) : toujours correctes, pas de régression.
- Sélecteur de couleur du graphe (taille auto, corrigé précédemment en #91) : toujours correct, y compris sur fenêtre très étroite — pas de régression.

🤖 Généré avec [Claude Code](https://claude.com/claude-code)