### PR TITLE
fix(statistiques): couleurs, tri et repere 12h pour l'histogramme et les camemberts

### DIFF
--- a/front/src/composables/use-statistics/__tests__/category-pie-chart.utils.test.ts
+++ b/front/src/composables/use-statistics/__tests__/category-pie-chart.utils.test.ts
@@ -2,6 +2,7 @@ import {
   buildCategoryPieChartData,
   buildCategoryPieChartColors,
   calculateUnaccountedPieDuration,
+  filterAndSortPieChartObservables,
   shouldIncludePauseSegment,
 } from '../category-pie-chart.utils';
 import { IObservableStatistics } from '@services/observations/statistics.interface';
@@ -64,7 +65,7 @@ describe('buildCategoryPieChartData', () => {
     });
   });
 
-  it('sums to 100% in separate-state mode with pauses', () => {
+  it('sums to 100% in separate-state mode with pauses, sorted by descending duration', () => {
     const data = buildCategoryPieChartData(baseStats, {
       treatPausesAsSeparateState: true,
       pauseSegmentLabel: 'Pause',
@@ -75,8 +76,12 @@ describe('buildCategoryPieChartData', () => {
     const total = data.reduce((sum, segment) => sum + segment.value, 0);
     expect(total).toBeCloseTo(100, 5);
 
-    expect(data[0].value).toBeCloseTo(30, 5);
-    expect(data[1].value).toBeCloseTo(60, 5);
+    // obs-b (6 min) has the longer duration, so it sorts before obs-a (3 min);
+    // Pause always comes last among accounted segments.
+    expect(data[0].label).toBe('obsB');
+    expect(data[0].value).toBeCloseTo(60, 5);
+    expect(data[1].label).toBe('obsA');
+    expect(data[1].value).toBeCloseTo(30, 5);
     expect(data[2].value).toBeCloseTo(10, 5);
   });
 
@@ -185,6 +190,47 @@ describe('calculateUnaccountedPieDuration', () => {
 
   it('returns 0 when there is no gap', () => {
     expect(calculateUnaccountedPieDuration(baseStats, true)).toBe(0);
+  });
+});
+
+describe('filterAndSortPieChartObservables', () => {
+  it('drops observables with no duration and no count', () => {
+    const observables = [
+      mockObservable('obs-a', 'obsA', 0, 0, 0),
+      mockObservable('obs-b', 'obsB', 60_000, 100, 1),
+    ];
+
+    expect(filterAndSortPieChartObservables(observables).map((o) => o.observableName)).toEqual([
+      'obsB',
+    ]);
+  });
+
+  it('sorts by descending duration', () => {
+    const observables = [
+      mockObservable('obs-a', 'obsA', 60_000, 0, 1),
+      mockObservable('obs-b', 'obsB', 180_000, 0, 1),
+      mockObservable('obs-c', 'obsC', 120_000, 0, 1),
+    ];
+
+    expect(filterAndSortPieChartObservables(observables).map((o) => o.observableName)).toEqual([
+      'obsB',
+      'obsC',
+      'obsA',
+    ]);
+  });
+
+  it('keeps the category declaration order for ties', () => {
+    const observables = [
+      mockObservable('obs-a', 'obsA', 60_000, 0, 1),
+      mockObservable('obs-b', 'obsB', 60_000, 0, 1),
+      mockObservable('obs-c', 'obsC', 120_000, 0, 1),
+    ];
+
+    expect(filterAndSortPieChartObservables(observables).map((o) => o.observableName)).toEqual([
+      'obsC',
+      'obsA',
+      'obsB',
+    ]);
   });
 });
 

--- a/front/src/composables/use-statistics/category-pie-chart.utils.ts
+++ b/front/src/composables/use-statistics/category-pie-chart.utils.ts
@@ -42,6 +42,26 @@ export function shouldIncludePauseSegment(
   return treatPausesAsSeparateState && pauseDuration > 0;
 }
 
+/**
+ * Filters out observables with no data and orders the rest by descending
+ * duration (the pie chart starts at 12 o'clock and draws clockwise, so this
+ * ordering puts the largest slice first / at the top). Ties keep their
+ * original position in the category. Used by both the data segments and the
+ * color list so the two stay aligned.
+ */
+export function filterAndSortPieChartObservables<
+  T extends { onDuration: number; onCount: number },
+>(observables: T[]): T[] {
+  return observables
+    .map((obs, index) => ({ obs, index }))
+    .filter(({ obs }) => obs.onDuration > 0 || obs.onCount > 0)
+    .sort((a, b) => {
+      const durationDiff = (b.obs.onDuration || 0) - (a.obs.onDuration || 0);
+      return durationDiff !== 0 ? durationDiff : a.index - b.index;
+    })
+    .map(({ obs }) => obs);
+}
+
 type PieStatsInput = Pick<
   ICategoryStatistics,
   | 'observables'
@@ -118,12 +138,7 @@ export function buildCategoryPieChartData(
   );
   const pieDenominator = resolvePieDenominator(stats, includePauseSegment);
 
-  const data = stats.observables
-    .filter((obs) => {
-      const hasDuration = obs.onDuration > 0;
-      const hasCount = obs.onCount > 0;
-      return hasDuration || hasCount;
-    })
+  const data = filterAndSortPieChartObservables(stats.observables)
     .map((obs) => {
       const value = pieDenominator > 0 ? (obs.onDuration / pieDenominator) * 100 : 0;
       return {

--- a/front/src/pages/userspace/statistics/_components/AmChartsBarChart.vue
+++ b/front/src/pages/userspace/statistics/_components/AmChartsBarChart.vue
@@ -61,9 +61,12 @@ export default defineComponent({
         label: string;
         value: number;
         formattedValue?: string;
+        /** Per-bar color; falls back to `colors` when absent. */
+        color?: string;
       }>>,
       required: true,
     },
+    /** Fallback fill used for bars that don't carry their own `color`. */
     colors: {
       type: String,
       default: '#1976D2',
@@ -187,61 +190,35 @@ export default defineComponent({
         return text;
       });
 
+      // Each bar takes the color of its own observable (matching the pie
+      // chart/legend) when the data row carries one; otherwise fall back
+      // to the single `colors` prop.
+      series.columns.template.adapters.add('fill', (fill, target) => {
+        const context = target.dataItem?.dataContext as any;
+        return context?.color ? am5.color(context.color) : fill;
+      });
+      series.columns.template.adapters.add('stroke', (stroke, target) => {
+        const context = target.dataItem?.dataContext as any;
+        return context?.color ? am5.color(context.color) : stroke;
+      });
+
       /**
        * CONFIGURATION DES BARRES VERTICALES
        * ====================================
-       * 
-       * Les barres verticales sont configurées avec :
+       *
        * - cornerRadiusTL et cornerRadiusBL : coins arrondis en haut (top-left et bottom-left)
        *   car les barres partent du bas et montent vers le haut
-       * 
-       * Les labels sont positionnés en haut des barres :
-       * - locationY: 1 → position au sommet de la barre
-       * - centerY: am5.p100 → alignement vertical en haut
-       * - centerX: am5.p50 → centrage horizontal
-       * - textAlign: 'center' → texte centré
+       *
+       * La valeur de chaque barre n'est affichée qu'au survol (tooltip),
+       * pas en permanence au-dessus de la colonne.
        */
-      
+
       // Configure columns appearance
       series.columns.template.setAll({
         tooltipY: 0,
         strokeOpacity: 0,
         cornerRadiusTL: 4,
         cornerRadiusBL: 4,
-      });
-
-      // Enable and configure labels on bars using bullets
-      // Capture root in a local variable for TypeScript (root is guaranteed to be set at this point)
-      const currentRoot = root as am5.Root;
-      series.bullets.push(() => {
-        const label = am5.Label.new(currentRoot, {
-          text: '{formattedValue}',
-          fill: am5.color('#000'),
-          centerX: am5.p50,
-          centerY: am5.p100,
-          fontSize: 12,
-          textAlign: 'center',
-          paddingBottom: 5,
-        });
-
-        // Configure adapter for formattedValue
-        label.adapters.add('text', (text: string | undefined, target: any) => {
-          const dataItem = target.dataItem;
-          if (dataItem && dataItem.dataContext) {
-            const context = dataItem.dataContext as any;
-            if (context.formattedValue) {
-              return context.formattedValue;
-            }
-            // Fallback to value if no formattedValue
-            return String(context.value);
-          }
-          return text;
-        });
-
-        return am5.Bullet.new(currentRoot, {
-          locationY: 1,
-          sprite: label,
-        });
       });
 
       exporting = am5exporting.Exporting.new(root, {

--- a/front/src/pages/userspace/statistics/_components/CategoryStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/CategoryStatisticsView.vue
@@ -71,6 +71,7 @@ import {
   buildCategoryPieChartColors,
   buildCategoryPieChartData,
   calculateUnaccountedPieDuration,
+  filterAndSortPieChartObservables,
 } from 'src/composables/use-statistics/category-pie-chart.utils';
 import {
   resolveCategoryGraphColor,
@@ -176,10 +177,7 @@ export default defineComponent({
       const stats = statistics.sharedState.categoryStatistics;
       const protocol = observation.protocol?.sharedState?.currentProtocol;
       const categoryId = state.selectedCategoryId;
-      const observables =
-        stats?.observables?.filter(
-          (obs) => obs.onDuration > 0 || obs.onCount > 0,
-        ) || [];
+      const observables = filterAndSortPieChartObservables(stats?.observables || []);
       const resolvedColors = observables.map((obs) =>
         resolveObservableChartColor(obs.observableId, categoryId ?? '', protocol),
       );

--- a/front/src/pages/userspace/statistics/_components/CategoryStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/CategoryStatisticsView.vue
@@ -222,26 +222,43 @@ export default defineComponent({
       return !category.action || category.action === ProtocolItemActionEnum.Continuous;
     });
 
-    const occurrencesBarChartData = computed(() => {
+    // Une seule liste triée sert de source à la fois pour les barres et
+    // leurs couleurs, afin qu'elles restent alignées après le tri.
+    const occurrencesBarChartRows = computed(() => {
       const stats = statistics.sharedState.categoryStatistics;
       if (!stats || !stats.observables || stats.observables.length === 0) {
         return [];
       }
 
-      const data = stats.observables
-        .filter((obs) => obs.onCount > 0)
-        .map((obs) => {
+      const protocol = observation.protocol?.sharedState?.currentProtocol;
+      const categoryId = state.selectedCategoryId ?? '';
+
+      return stats.observables
+        .map((obs, index) => ({ obs, index }))
+        .filter(({ obs }) => obs.onCount > 0)
+        .map(({ obs, index }) => {
           const c = obs.onCount || 0;
           return {
             label: obs.observableName,
             value: c,
             formattedValue: formatOccurrenceCount(t, c),
+            color: resolveObservableChartColor(obs.observableId, categoryId, protocol),
+            index,
           };
-        });
-
-      return data.length > 0 ? data : [];
+        })
+        .sort((a, b) => (b.value !== a.value ? b.value - a.value : b.index - a.index));
     });
 
+    const occurrencesBarChartData = computed(() =>
+      occurrencesBarChartRows.value.map(({ label, value, formattedValue, color }) => ({
+        label,
+        value,
+        formattedValue,
+        color,
+      })),
+    );
+
+    // Fallback fill for AmChartsBarChart when a row has no resolved color.
     const barChartColors = computed(() => {
       return resolveCategoryGraphColor(
         state.selectedCategoryId,

--- a/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
@@ -463,22 +463,38 @@ export default defineComponent({
       );
     });
 
-    const barChartData = computed(() => {
+    // Une seule liste triée sert de source à la fois pour les barres et
+    // leurs couleurs, afin qu'elles restent alignées après le tri.
+    const barChartRows = computed(() => {
       const stats = statistics.sharedState.conditionalStatistics;
       if (!stats || !stats.targetCategory || !stats.targetCategory.observables) {
         return [];
       }
 
-      const data = stats.targetCategory.observables
-        .filter((obs) => obs.onCount > 0)
-        .map((obs) => ({
+      const protocol = observation.protocol?.sharedState?.currentProtocol;
+      const categoryId = state.targetCategoryId ?? '';
+
+      return stats.targetCategory.observables
+        .map((obs, index) => ({ obs, index }))
+        .filter(({ obs }) => obs.onCount > 0)
+        .map(({ obs, index }) => ({
           label: obs.observableName,
           value: obs.onCount || 0,
           formattedValue: formatOccurrenceCount(t, obs.onCount || 0),
-        }));
-
-      return data.length > 0 ? data : [];
+          color: resolveObservableChartColor(obs.observableId, categoryId, protocol),
+          index,
+        }))
+        .sort((a, b) => (b.value !== a.value ? b.value - a.value : b.index - a.index));
     });
+
+    const barChartData = computed(() =>
+      barChartRows.value.map(({ label, value, formattedValue, color }) => ({
+        label,
+        value,
+        formattedValue,
+        color,
+      })),
+    );
 
     const barChartColors = computed(() => {
       return resolveCategoryGraphColor(

--- a/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
+++ b/front/src/pages/userspace/statistics/_components/ConditionalStatisticsView.vue
@@ -186,6 +186,7 @@ import {
   buildCategoryPieChartColors,
   buildCategoryPieChartData,
   calculateUnaccountedPieDuration,
+  filterAndSortPieChartObservables,
 } from 'src/composables/use-statistics/category-pie-chart.utils';
 import AmChartsPieChart from './AmChartsPieChart.vue';
 import AmChartsBarChart from './AmChartsBarChart.vue';
@@ -447,10 +448,9 @@ export default defineComponent({
       const stats = statistics.sharedState.conditionalStatistics;
       const protocol = observation.protocol?.sharedState?.currentProtocol;
       const categoryId = state.targetCategoryId ?? '';
-      const observables =
-        stats?.targetCategory?.observables?.filter(
-          (obs) => obs.onDuration > 0 || obs.onCount > 0,
-        ) || [];
+      const observables = filterAndSortPieChartObservables(
+        stats?.targetCategory?.observables || [],
+      );
       const resolvedColors = observables.map((obs) =>
         resolveObservableChartColor(obs.observableId, categoryId, protocol),
       );


### PR DESCRIPTION
## Resume
Deux problemes signales dans l'onglet Statistiques :

### 1. Histogramme "Nombre d'occurrences" (vue par categorie et vue conditionnelle)
- Toutes les barres avaient la meme couleur, au lieu de la couleur propre a chaque observable.
- Les barres n'etaient pas triees par nombre d'occurrences.
- Un chiffre restait affiche en permanence au-dessus de chaque barre.

### 2. Camemberts "par categorie" (vue simple et vue conditionnelle/mode avance)
- Les segments n'etaient pas tries par duree.

## Changements
- `AmChartsBarChart.vue` : chaque ligne de donnees peut porter sa propre couleur (`color`), appliquee a la barre correspondante ; la couleur unique (`colors`) reste un repli. Retrait du label fixe au-dessus des barres (la valeur reste disponible au survol via le tooltip).
- `CategoryStatisticsView.vue` / `ConditionalStatisticsView.vue` :
  - Barres triees par occurrences decroissantes (egalite : ordre decroissant des observables dans la categorie), chaque barre coloree comme son observable (alignee sur le camembert/la legende via `resolveObservableChartColor`).
  - Segments du camembert tries par duree decroissante (egalite : ordre de declaration dans la categorie). Le camembert demarre deja a 12h et tourne dans le sens des aiguilles d'une montre (comportement par defaut d'amCharts5), donc le plus gros segment se retrouve desormais en haut. Le segment Pause reste en dernier parmi les segments comptes, suivi en tout dernier de l'eventuel segment residuel "Non renseigne" (comportement deja en place, non modifie).
- `category-pie-chart.utils.ts` : nouveau helper partage `filterAndSortPieChartObservables` pour garder les donnees du camembert et leurs couleurs alignees apres le tri.

## Test plan
- [x] `npm run typecheck` (front) : OK
- [x] `npx eslint` sur les fichiers modifies : OK
- [x] `npx jest src/composables/use-statistics` : 40 tests OK (dont nouveaux tests pour `filterAndSortPieChartObservables` et mise a jour du test de tri du camembert)
- [ ] Verification visuelle dans l'app avec une observation reelle (non testee dans cette session : necessite l'app Electron + donnees d'observation enregistrees)

Generated with Claude Code