### PR TITLE
[URGENT] fix(cloud): import des anciens fichiers .chronic depuis le Cloud échoue (400)

### DIFF
--- a/front/src/composables/use-cloud/index.ts
+++ b/front/src/composables/use-cloud/index.ts
@@ -179,7 +179,13 @@ export function useCloud() {
         }
 
         // Créer un fichier File pour l'import via le backend
-        const fileName = chronicle.name;
+        // Le nom affiché (chronicle.name) peut ne pas contenir l'extension, notamment
+        // pour les anciens fichiers .chronic : le backend route le parsing sur l'extension
+        // du nom de fichier, donc on force l'extension attendue avant l'envoi.
+        const ext = chronicle.isJchronic ? '.jchronic' : '.chronic';
+        const fileName = chronicle.name.toLowerCase().endsWith(ext)
+          ? chronicle.name
+          : `${chronicle.name}${ext}`;
         const file = new File([downloadResult.content], fileName, {
           type: chronicle.isJchronic ? 'application/json' : 'application/octet-stream',
         });

--- a/front/src/composables/use-cloud/index.ts
+++ b/front/src/composables/use-cloud/index.ts
@@ -181,11 +181,11 @@ export function useCloud() {
         // Créer un fichier File pour l'import via le backend
         // Le nom affiché (chronicle.name) peut ne pas contenir l'extension, notamment
         // pour les anciens fichiers .chronic : le backend route le parsing sur l'extension
-        // du nom de fichier, donc on force l'extension attendue avant l'envoi.
+        // du nom de fichier (endsWith sensible à la casse), donc on normalise
+        // l'extension attendue avant l'envoi.
         const ext = chronicle.isJchronic ? '.jchronic' : '.chronic';
-        const fileName = chronicle.name.toLowerCase().endsWith(ext)
-          ? chronicle.name
-          : `${chronicle.name}${ext}`;
+        const baseName = chronicle.name.replace(/\.j?chronic$/i, '');
+        const fileName = `${baseName}${ext}`;
         const file = new File([downloadResult.content], fileName, {
           type: chronicle.isJchronic ? 'application/json' : 'application/octet-stream',
         });


### PR DESCRIPTION
## URGENT

Bug bloquant signalé par une testeuse : impossible de télécharger/importer un fichier `.chronic` (ancien format) depuis le Cloud ActoGraph. L'app affiche « Erreur de téléchargement — Request failed with status code 400 ».

## Cause

Pour les fichiers `.chronic` uploadés via l'ancienne app, le champ `name` renvoyé par l'API Cloud (`actograph.io`) ne contient pas l'extension (ex. `"J2 avec aprembis"` au lieu de `"J2 avec aprembis.chronic"`).

Lors du téléchargement depuis le Cloud, `front/src/composables/use-cloud/index.ts` utilisait ce nom tel quel pour construire l'objet `File` envoyé à l'API d'import (`POST /observations/import`). Ce endpoint route le parsing (JSON `.jchronic` vs binaire Qt `.chronic`) uniquement sur l'extension du nom de fichier reçu (`api/src/core/observations/controllers/observation.controller.ts`) — sans extension, il rejette la requête avec un 400.

Les fichiers `.jchronic` ne sont pas concernés : leur `name` inclut déjà l'extension au moment de l'upload.

## Correctif

Dans `downloadChronicle` (`use-cloud/index.ts`), on force l'extension attendue (`.chronic` ou `.jchronic`, déterminée via `chronicle.isJchronic`) sur le nom de fichier avant l'envoi, si elle est absente.

## Vérifié

- Typecheck (`vue-tsc`) OK sur le fichier modifié.
- L'import local d'un `.chronic` (menu "Importer depuis un fichier") n'est pas affecté : il utilise le vrai nom de fichier du disque (avec extension), pas les métadonnées Cloud. Confirmé par les tests existants `chronic-v1.parser.test.ts` (4/4 passent).
- Vérification complète en conditions réelles (compte Cloud + vieux fichier `.chronic`) non faisable depuis cet environnement (nécessite des identifiants Cloud réels) — à confirmer côté testeuse après merge.

## Test plan

- [ ] Sylvain : merger et déployer l'API + le front
- [ ] Valérie : retélécharger un des fichiers `.chronic` listés dans le Cloud (ex. "J2 avec aprembis") et confirmer que l'import fonctionne

🤖 Generated with [Claude Code](https://claude.com/claude-code)