### PR TITLE
feat(graph): étirement indépendant des axes X/Y et visibilité des catégories

### DIFF
--- a/api/src/core/observations/dtos/protocol-item-graph-preferences.dto.ts
+++ b/api/src/core/observations/dtos/protocol-item-graph-preferences.dto.ts
@@ -3,6 +3,7 @@ import {
   IsOptional,
   IsNumber,
   IsEnum,
+  IsBoolean,
   Min,
   Max,
 } from 'class-validator';
@@ -30,4 +31,8 @@ export class UpdateProtocolItemGraphPreferencesDto {
   @IsString()
   @IsOptional()
   supportCategoryId?: string | null;
+
+  @IsBoolean()
+  @IsOptional()
+  visible?: boolean;
 }

--- a/api/src/core/observations/entities/protocol.entity.ts
+++ b/api/src/core/observations/entities/protocol.entity.ts
@@ -16,6 +16,7 @@ export interface IGraphPreferences {
   displayMode?: DisplayModeEnum;
   supportCategoryId?: string | null;
   supportCategoryName?: string | null;
+  visible?: boolean;
 }
 
 export interface ProtocolItem {

--- a/api/src/core/observations/services/protocol/items.ts
+++ b/api/src/core/observations/services/protocol/items.ts
@@ -615,6 +615,9 @@ export class Items {
       targetItem.graphPreferences.supportCategoryId =
         normalizedPreferences.supportCategoryId;
     }
+    if (normalizedPreferences.visible !== undefined) {
+      targetItem.graphPreferences.visible = normalizedPreferences.visible;
+    }
 
     // Update the protocol with the new items
     protocol.items = JSON.stringify(items);

--- a/front/src/i18n/en-US/index.ts
+++ b/front/src/i18n/en-US/index.ts
@@ -492,6 +492,12 @@ export default {
     timeFormatMinuteSecond: 'mm:ss',
     timeFormatSecond: 'sec',
     timeFormatMinuteSecondMs: 'mm:ss:ms',
+    toggleCategoryVisibility: 'Show/hide this category on the graph',
+    axisScaleTooltip: 'Adjust display',
+    axisScaleTitle: 'Adjust display',
+    axisScaleXLabel: 'Stretch time axis',
+    axisScaleYLabel: 'Compact categories',
+    axisScaleReset: 'Reset',
   },
   appRoot: {
     updateAvailableTitle: 'Update available',

--- a/front/src/i18n/fr/index.ts
+++ b/front/src/i18n/fr/index.ts
@@ -499,6 +499,12 @@ export default {
     timeFormatMinuteSecond: 'mn:sec',
     timeFormatSecond: 'sec',
     timeFormatMinuteSecondMs: 'mn:sec:ms',
+    toggleCategoryVisibility: 'Afficher/masquer cette catégorie sur le graphe',
+    axisScaleTooltip: 'Ajuster l\'affichage',
+    axisScaleTitle: 'Ajuster l\'affichage',
+    axisScaleXLabel: 'Étirer l\'axe du temps',
+    axisScaleYLabel: 'Compacter les catégories',
+    axisScaleReset: 'Réinitialiser',
   },
   appRoot: {
     updateAvailableTitle: 'Mise à jour disponible',

--- a/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
+++ b/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
@@ -39,6 +39,17 @@
           <div class="category-container">
             <!-- Ligne Catégorie -->
             <div class="category-row customization-row">
+              <!-- Visibilité -->
+              <div class="cell-visible">
+                <q-checkbox
+                  :model-value="category.graphPreferences?.visible !== false"
+                  dense
+                  @update:model-value="methods.onCategoryVisibleChange(category.id, $event)"
+                >
+                  <q-tooltip>{{ $t('graphUi.toggleCategoryVisibility') }}</q-tooltip>
+                </q-checkbox>
+              </div>
+
               <!-- Nom de la catégorie -->
               <DrawerLabelCell
                 :text="category.name ?? ''"
@@ -145,6 +156,9 @@
                 :key="observable.id"
                 class="observable-row customization-row"
               >
+                <!-- Visibilité (espace réservé, propriété de la catégorie uniquement) -->
+                <div class="cell-visible" aria-hidden="true" />
+
                 <!-- Nom de l'observable -->
                 <DrawerLabelCell
                   :text="observable.name ?? ''"
@@ -266,8 +280,8 @@ import {
 } from './graph-preferences.utils';
 
 const COMPACT_MODE_THRESHOLD = 400; // Largeur en pixels pour activer le mode compact
-const GRID_COLUMN_WIDTHS = [140, 120, 36, 90, 140, 140];
-const GRID_COLUMN_WIDTHS_COMPACT = [100, 100, 36, 80, 120, 120];
+const GRID_COLUMN_WIDTHS = [36, 140, 120, 36, 90, 140, 140];
+const GRID_COLUMN_WIDTHS_COMPACT = [32, 100, 100, 36, 80, 120, 120];
 const GRID_GAP = 8;
 const GRID_GAP_COMPACT = 4;
 const ROW_PADDING_X = 16; // padding-left 12px + padding-right 4px
@@ -282,6 +296,7 @@ const computeMinContentWidth = (compact: boolean): number => {
 };
 
 const GRID_LAYOUT_KEYS = [
+  'visible',
   'name',
   'display',
   'color',
@@ -558,6 +573,10 @@ export default defineComponent({
         methods.updateCategoryPreference(categoryId, { strokeWidth: val ?? undefined });
       },
 
+      onCategoryVisibleChange: (categoryId: string, val: boolean) => {
+        methods.updateCategoryPreference(categoryId, { visible: val });
+      },
+
       onCategoryPatternChange: (categoryId: string, val: BackgroundPatternEnum) => {
         methods.updateCategoryPreference(categoryId, { backgroundPattern: val });
       },
@@ -646,7 +665,8 @@ export default defineComponent({
 
           const isStructuralCategoryChange =
             sanitizedPreference.displayMode !== undefined ||
-            sanitizedPreference.supportCategoryId !== undefined;
+            sanitizedPreference.supportCategoryId !== undefined ||
+            sanitizedPreference.visible !== undefined;
 
           if (isStructuralCategoryChange) {
             // Affecte l'axe Y / layout : full setData+draw
@@ -958,6 +978,7 @@ export default defineComponent({
 .customization-row {
   display: grid;
   grid-template-columns:
+    var(--gc-col-visible)
     var(--gc-col-name)
     var(--gc-col-display)
     var(--gc-col-color)
@@ -1025,6 +1046,12 @@ export default defineComponent({
     white-space: nowrap;
     min-width: 0;
   }
+}
+
+.cell-visible {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
 }
 
 .cell-color {

--- a/front/src/pages/userspace/analyse/_components/graph-customization-drawer/graph-preferences.utils.ts
+++ b/front/src/pages/userspace/analyse/_components/graph-customization-drawer/graph-preferences.utils.ts
@@ -58,6 +58,10 @@ export function sanitizeGraphPreferencePatch(
     patch.supportCategoryId = null;
   }
 
+  if (typeof preference.visible === 'boolean') {
+    patch.visible = preference.visible;
+  }
+
   return patch;
 }
 

--- a/front/src/pages/userspace/analyse/_components/graph/Index.vue
+++ b/front/src/pages/userspace/analyse/_components/graph/Index.vue
@@ -60,6 +60,59 @@
         <q-separator v-if="showSeparatorBeforeReset" vertical />
         <q-btn
           flat
+          round
+          dense
+          icon="mdi-tune"
+          color="grey-8"
+        >
+          <q-tooltip>{{ $t('graphUi.axisScaleTooltip') }}</q-tooltip>
+          <q-menu anchor="bottom right" self="top right" :offset="[0, 8]">
+            <div class="q-pa-md" style="min-width: 260px">
+              <div class="text-weight-medium q-mb-sm">{{ $t('graphUi.axisScaleTitle') }}</div>
+
+              <div class="text-caption text-grey-7">{{ $t('graphUi.axisScaleXLabel') }}</div>
+              <q-slider
+                :model-value="axisStretch.x"
+                :min="0.5"
+                :max="3"
+                :step="0.25"
+                dense
+                color="primary"
+                label
+                :label-value="`${axisStretch.x}×`"
+                class="q-mb-md"
+                @update:model-value="methods.onAxisStretchXChange"
+              />
+
+              <div class="text-caption text-grey-7">{{ $t('graphUi.axisScaleYLabel') }}</div>
+              <q-slider
+                :model-value="axisStretch.y"
+                :min="0.4"
+                :max="1"
+                :step="0.1"
+                dense
+                color="primary"
+                label
+                :label-value="`${axisStretch.y}×`"
+                class="q-mb-md"
+                @update:model-value="methods.onAxisStretchYChange"
+              />
+
+              <q-btn
+                flat
+                dense
+                no-caps
+                color="primary"
+                :label="$t('graphUi.axisScaleReset')"
+                class="full-width"
+                @click="methods.resetAxisStretch"
+              />
+            </div>
+          </q-menu>
+        </q-btn>
+        <q-separator v-if="showSeparatorBeforeReset" vertical />
+        <q-btn
+          flat
           dense
           no-caps
           color="grey-8"
@@ -159,7 +212,10 @@ import { useObservation } from 'src/composables/use-observation';
 import { observationService } from '@services/observations/index.service';
 import { useI18n } from 'vue-i18n';
 import { DEFAULT_GRAPH_COLOR, TimeDisplayFormatEnum } from '@actograph/graph';
-import { hasReadingsAfterLastStop as detectReadingsAfterLastStop } from '@actograph/core';
+import {
+  hasReadingsAfterLastStop as detectReadingsAfterLastStop,
+  isCategoryVisible,
+} from '@actograph/core';
 import {
   getObservableGraphPreferences,
   resolveGraphColor,
@@ -225,6 +281,13 @@ export default defineComponent({
     // spec-pr-format-affichage-temps-graphe.md) : restauré à l'ouverture de
     // la chronique, sauvegardé à chaque changement de sélection.
     const timeDisplayFormat = ref<TimeDisplayFormatEnum>(TimeDisplayFormatEnum.Auto);
+
+    // Étirement indépendant des axes (x = temps, y = catégories), par-dessus
+    // le zoom uniforme existant. Persisté par chronique dans
+    // observation.meta.graphXStretch/graphYCompact, même pattern que
+    // timeDisplayFormat ci-dessus : restauré à l'ouverture, sauvegardé à
+    // chaque changement de réglage.
+    const axisStretch = reactive({ x: 1, y: 1 });
 
     const timeFormatOptions = computed(() => {
       void locale.value;
@@ -313,6 +376,48 @@ export default defineComponent({
           console.error('Failed to persist timeDisplayFormat to observation meta:', error);
         }
       },
+      onAxisStretchXChange: (value: number | null) => {
+        if (value === null) return;
+        methods.setAxisStretch({ x: value });
+      },
+      onAxisStretchYChange: (value: number | null) => {
+        if (value === null) return;
+        methods.setAxisStretch({ y: value });
+      },
+      resetAxisStretch: () => {
+        methods.setAxisStretch({ x: 1, y: 1 });
+      },
+      setAxisStretch: (next: { x?: number; y?: number }) => {
+        axisStretch.x = next.x ?? axisStretch.x;
+        axisStretch.y = next.y ?? axisStretch.y;
+        graph.setAxisStretch(next);
+        void methods.persistAxisStretch({ x: axisStretch.x, y: axisStretch.y });
+      },
+      // Même pattern que persistTimeDisplayFormat ci-dessus : sauvegarde non
+      // bloquante dans observation.meta, l'affichage local a déjà changé.
+      persistAxisStretch: async (next: { x: number; y: number }) => {
+        const current = observation.sharedState.currentObservation;
+        if (!current?.id) return;
+
+        observation.sharedState.currentObservation = {
+          ...current,
+          meta: { ...(current.meta ?? {}), graphXStretch: next.x, graphYCompact: next.y },
+        } as typeof observation.sharedState.currentObservation;
+
+        try {
+          const updated = await observationService.update(current.id, {
+            meta: { graphXStretch: next.x, graphYCompact: next.y },
+          });
+          if (updated?.meta) {
+            observation.sharedState.currentObservation = {
+              ...observation.sharedState.currentObservation,
+              meta: updated.meta,
+            } as typeof observation.sharedState.currentObservation;
+          }
+        } catch (error) {
+          console.error('Failed to persist axis stretch to observation meta:', error);
+        }
+      },
       // Construit le canvas de légende (noms de catégories/observables + pastilles
       // de couleur). Partagé par tous les exports impliquant la légende (légende
       // seule ou combinée graphe + légende), pour garantir un contenu identique.
@@ -330,6 +435,7 @@ export default defineComponent({
         const rows: Array<{ label: string; color: string; isCategory?: boolean }> = [];
         for (const category of items) {
           if (String(category?.type ?? '').toLowerCase() !== 'category') continue;
+          if (!isCategoryVisible(category)) continue;
           const categoryColor = category?.graphPreferences?.color || DEFAULT_GRAPH_COLOR;
           rows.push({
             // Le nom de la catégorie est une donnée utilisateur, pas un texte à
@@ -559,6 +665,25 @@ export default defineComponent({
       { immediate: true }
     );
 
+    // Restaure l'étirement des axes depuis observation.meta quand une
+    // chronique est chargée (persisté par persistAxisStretch ci-dessus).
+    // Même politique que timeDisplayFormat : pas de repli sur la chronique
+    // précédemment ouverte, une valeur absente ou invalide retombe sur 1×.
+    watch(
+      () => [
+        observation.sharedState.currentObservation?.meta?.graphXStretch,
+        observation.sharedState.currentObservation?.meta?.graphYCompact,
+      ] as const,
+      ([xFromMeta, yFromMeta]) => {
+        const nextX = typeof xFromMeta === 'number' && Number.isFinite(xFromMeta) ? xFromMeta : 1;
+        const nextY = typeof yFromMeta === 'number' && Number.isFinite(yFromMeta) ? yFromMeta : 1;
+        axisStretch.x = nextX;
+        axisStretch.y = nextY;
+        graph.setAxisStretch({ x: nextX, y: nextY });
+      },
+      { immediate: true }
+    );
+
     // Computed property pour déterminer si le séparateur avant le reset est nécessaire
     const showSeparatorBeforeReset = computed(() => {
       // Le séparateur est nécessaire seulement s'il y a des boutons de zoom avant le reset
@@ -583,6 +708,7 @@ export default defineComponent({
       exportFormatOptions,
       timeDisplayFormat,
       timeFormatOptions,
+      axisStretch,
       methods,
       customization,
       props,

--- a/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
+++ b/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
@@ -116,7 +116,9 @@ export const useGraph = (options?: {
       });
       if (generation !== redrawGeneration || sharedState.pixiApp !== pixiApp) return;
 
-      await pixiApp.draw();
+      // Réapplique l'étirement persisté (peut avoir été défini avant ready via
+      // le watch meta dans Index.vue) ; setAxisStretch déclenche le draw.
+      await pixiApp.setAxisStretch(sharedState.axisStretch);
       if (generation !== redrawGeneration || sharedState.pixiApp !== pixiApp) return;
     } catch (error) {
       // Guard rail: don't break the page on transient/partial data while editing.

--- a/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
+++ b/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
@@ -35,6 +35,10 @@ const sharedState = shallowReactive({
   graphRenderOptions: {
     ...DEFAULT_GRAPH_RENDER_OPTIONS,
   } as IGraphRenderOptions,
+  // Miroir réactif de PixiApp.axisStretch, pour piloter les sliders du menu
+  // de réglages d'échelle (graph/Index.vue). PixiApp reste la source de
+  // vérité pour le rendu ; ceci n'est utile qu'à l'affichage des sliders.
+  axisStretch: { x: 1, y: 1 },
 });
 
 /** Debounce partagé : Index (watches) et drawer coalescent ensemble. */
@@ -179,6 +183,21 @@ export const useGraph = (options?: {
     }
   };
 
+  /**
+   * Étirement indépendant des axes (x = temps, y = catégories), par-dessus le
+   * zoom uniforme existant. La persistance par chronique
+   * (observation.meta.graphXStretch/graphYCompact) est gérée par graph/Index.vue.
+   */
+  const setAxisStretch = (next: { x?: number; y?: number }): void => {
+    sharedState.axisStretch = {
+      x: next.x ?? sharedState.axisStretch.x,
+      y: next.y ?? sharedState.axisStretch.y,
+    };
+    if (sharedState.ready && sharedState.pixiApp) {
+      void sharedState.pixiApp.setAxisStretch(next);
+    }
+  };
+
   const refreshGraph = (attempt = 0): void => {
     if (!sharedState.ready || !sharedState.pixiApp) {
       return;
@@ -313,6 +332,7 @@ export const useGraph = (options?: {
     sharedState,
     onCanvasResize,
     setTimeDisplayFormat,
+    setAxisStretch,
     /** Redessin complet immédiat (setData + draw). */
     requestRedraw,
     /** Redessin complet coalescé (50 ms). */

--- a/front/src/services/observations/interface.ts
+++ b/front/src/services/observations/interface.ts
@@ -48,6 +48,7 @@ export interface IGraphPreferences {
   backgroundPattern?: BackgroundPatternEnum;
   displayMode?: DisplayModeEnum;
   supportCategoryId?: string | null;
+  visible?: boolean;
 }
 
 export interface IProtocolItem {

--- a/packages/core/src/types/protocol.types.ts
+++ b/packages/core/src/types/protocol.types.ts
@@ -16,6 +16,8 @@ export interface IGraphPreferences {
   supportCategoryId?: string | null;
   /** Référence portable par nom de catégorie (export/import sans IDs). */
   supportCategoryName?: string | null;
+  /** Visibilité de la catégorie sur le graphe. Non défini = visible (opt-out). Catégorie uniquement, non héritée par les observables. */
+  visible?: boolean;
 }
 
 /**

--- a/packages/core/src/utils/graph-preferences.ts
+++ b/packages/core/src/utils/graph-preferences.ts
@@ -124,6 +124,18 @@ export function mergeGraphPreferences(
 }
 
 /**
+ * Détermine si une catégorie doit être affichée sur le graphe.
+ * Non défini = visible (comportement opt-out). Propriété propre à la
+ * catégorie, comme displayMode/supportCategoryId : pas d'héritage vers les
+ * observables.
+ */
+export function isCategoryVisible(category: {
+  graphPreferences?: IGraphPreferences | null;
+}): boolean {
+  return category.graphPreferences?.visible !== false;
+}
+
+/**
  * Retourne la couleur effective à partir des préférences résolues.
  */
 export function resolveGraphColor(

--- a/packages/graph/src/__tests__/viewport.utils.test.ts
+++ b/packages/graph/src/__tests__/viewport.utils.test.ts
@@ -39,15 +39,27 @@ describe('viewport.utils', () => {
         { width: 400, height: 300 },
         { width: 800, height: 600 },
         1,
+        1,
       );
       expect(position).toEqual({ x: 200, y: 150 });
+    });
+
+    it('centers each axis independently when scaleX differs from scaleY', () => {
+      const position = computeFitViewportPosition(
+        { width: 400, height: 300 },
+        { width: 800, height: 600 },
+        1,
+        2,
+      );
+      // scaledWidth = 400 -> centered x = 200 ; scaledHeight = 600 -> fills canvas, y = 0
+      expect(position).toEqual({ x: 200, y: 0 });
     });
   });
 
   describe('clampViewport', () => {
     it('prevents panning into empty space vertically', () => {
       const clamped = clampViewport(
-        { x: 0, y: 500, scale: 1 },
+        { x: 0, y: 500, scaleX: 1, scaleY: 1 },
         { width: 800, height: 1200 },
         { width: 800, height: 600 },
       );
@@ -57,7 +69,7 @@ describe('viewport.utils', () => {
 
     it('centers plot when scaled smaller than canvas', () => {
       const clamped = clampViewport(
-        { x: -200, y: -100, scale: 0.5 },
+        { x: -200, y: -100, scaleX: 0.5, scaleY: 0.5 },
         { width: 400, height: 300 },
         { width: 800, height: 600 },
       );
@@ -69,26 +81,48 @@ describe('viewport.utils', () => {
       const world = { width: 800, height: 1200 };
       const canvas = { width: 800, height: 600 };
       const fitScale = computeFitScale(world, canvas, minScale, maxScale);
-      const fitPos = computeFitViewportPosition(world, canvas, fitScale);
+      const fitPos = computeFitViewportPosition(world, canvas, fitScale, fitScale);
 
-      let scale = fitScale * 1.2 * 0.8;
-      const clamped = clampViewport({ x: fitPos.x, y: fitPos.y, scale }, world, canvas);
+      const scale = fitScale * 1.2 * 0.8;
+      const clamped = clampViewport(
+        { x: fitPos.x, y: fitPos.y, scaleX: scale, scaleY: scale },
+        world,
+        canvas,
+      );
 
-      expect(clamped.scale * world.height).toBeLessThanOrEqual(canvas.height);
-      expect(clamped.y).toBeGreaterThanOrEqual(canvas.height - clamped.scale * world.height - 24);
+      expect(clamped.scaleY * world.height).toBeLessThanOrEqual(canvas.height);
+      expect(clamped.y).toBeGreaterThanOrEqual(canvas.height - clamped.scaleY * world.height - 24);
+      expect(clamped.y).toBeLessThanOrEqual(24);
+    });
+
+    it('clamps width and height independently when scaleX differs from scaleY', () => {
+      const world = { width: 800, height: 1200 };
+      const canvas = { width: 800, height: 600 };
+      // scaleX fits width exactly (no horizontal overscroll possible), scaleY zooms in on height.
+      const clamped = clampViewport(
+        { x: -999, y: -999, scaleX: 1, scaleY: 2 },
+        world,
+        canvas,
+      );
+
+      // Width == canvas width at scaleX=1 -> horizontally centered, not clamped to -999.
+      expect(clamped.x).toBe(0);
+      // Height clamp still allows panning within bounds (not centered).
+      expect(clamped.y).toBeGreaterThanOrEqual(canvas.height - world.height * 2 - 24);
       expect(clamped.y).toBeLessThanOrEqual(24);
     });
   });
 
   describe('computeFitViewport', () => {
-    it('returns scale and centered position for export fit', () => {
+    it('returns uniform scaleX/scaleY and centered position for export fit', () => {
       const fit = computeFitViewport(
         { width: 400, height: 1200 },
         { width: 800, height: 600 },
         minScale,
         maxScale,
       );
-      expect(fit.scale).toBeCloseTo(0.5);
+      expect(fit.scaleX).toBeCloseTo(0.5);
+      expect(fit.scaleY).toBeCloseTo(0.5);
       expect(fit.x).toBe(300);
       expect(fit.y).toBe(0);
     });
@@ -98,7 +132,8 @@ describe('viewport.utils', () => {
     it('preserves user zoom scale after canvas resize', () => {
       const world = { width: 800, height: 1200 };
       const oldCanvas = { width: 800, height: 600 };
-      const userViewport = { x: -50, y: -100, scale: 1.5 };
+      const userViewport = { x: -50, y: -100, scaleX: 1.5, scaleY: 1.5 };
+      void oldCanvas;
 
       const clamped = preserveViewportOnResize(
         userViewport,
@@ -106,7 +141,8 @@ describe('viewport.utils', () => {
         { width: 1024, height: 768 },
       );
 
-      expect(clamped.scale).toBe(1.5);
+      expect(clamped.scaleX).toBe(1.5);
+      expect(clamped.scaleY).toBe(1.5);
       expect(clamped.x).toBeLessThanOrEqual(24);
       expect(clamped.y).toBeLessThanOrEqual(24);
     });
@@ -116,13 +152,13 @@ describe('viewport.utils', () => {
     it('forces full-graph fit independent of user zoom', () => {
       const world = { width: 1600, height: 2400 };
       const exportCanvas = { width: 800, height: 600 };
-      const userZoomed = { x: -400, y: -800, scale: 2.5 };
+      const userZoomed = { x: -400, y: -800, scaleX: 2.5, scaleY: 2.5 };
 
       const exportFit = computeFitViewport(world, exportCanvas, minScale, maxScale);
       const restored = preserveViewportOnResize(userZoomed, world, exportCanvas);
 
-      expect(exportFit.scale).toBeLessThan(userZoomed.scale);
-      expect(restored.scale).toBe(userZoomed.scale);
+      expect(exportFit.scaleX).toBeLessThan(userZoomed.scaleX);
+      expect(restored.scaleX).toBe(userZoomed.scaleX);
       expect(restored.x).not.toBe(exportFit.x);
     });
   });

--- a/packages/graph/src/pixi-app/axis/x-axis.ts
+++ b/packages/graph/src/pixi-app/axis/x-axis.ts
@@ -86,6 +86,12 @@ export class xAxis extends BaseGroup {
   private ticks: { dateTime: Date; label: string; pos?: number }[] = [];
   private axisStart: { x: number; y: number } | null = null;
   private axisEnd: { x: number; y: number } | null = null;
+  /** Voir YAxis.axisStretch : contre-scale les labels quand scaleX ≠ scaleY. */
+  private axisStretch = { x: 1, y: 1 };
+
+  public setAxisStretch(stretch: { x: number; y: number }): void {
+    this.axisStretch = stretch;
+  }
 
   public getAxisStart() {
     return { ...this.axisStart };
@@ -465,13 +471,22 @@ export class xAxis extends BaseGroup {
           fontFamily: this.styleOptions.label.fontFamily,
         },
       });
-      label.x = tickXpos;
-      label.y = xAxisStart.y + 12;
       label.anchor.set(-0.05, 0);
       label.angle = 45;
       label.visible = true;
       label.alpha = 1;
-      this.labelsContainer.addChild(label);
+      // Le label est incliné à 45° : contre-scaler directement le Text
+      // mélangerait rotation et échelle anisotrope sur la même matrice locale
+      // et le ferait apparaître cisaillé. On isole la contre-échelle sur un
+      // conteneur parent non-tourné : composée avec le scale anisotrope du
+      // viewport (diagonal lui aussi), elle s'annule exactement et ne laisse
+      // que la rotation, quel que soit l'étirement courant.
+      const labelWrapper = new Container();
+      labelWrapper.x = tickXpos;
+      labelWrapper.y = xAxisStart.y + 12;
+      labelWrapper.scale.set(1 / this.axisStretch.x, 1 / this.axisStretch.y);
+      labelWrapper.addChild(label);
+      this.labelsContainer.addChild(labelWrapper);
     }
 
     const formatMentionText = this.getFormatMentionText();
@@ -497,6 +512,8 @@ export class xAxis extends BaseGroup {
       formatMention.angle = 0;
       formatMention.visible = true;
       formatMention.alpha = 1;
+      // Pas de rotation ici : contre-scale directe sans risque de cisaillement.
+      formatMention.scale.set(1 / this.axisStretch.x, 1 / this.axisStretch.y);
       this.labelsContainer.addChild(formatMention);
     }
 

--- a/packages/graph/src/pixi-app/axis/y-axis.ts
+++ b/packages/graph/src/pixi-app/axis/y-axis.ts
@@ -2,7 +2,7 @@ import { Application, Text } from 'pixi.js';
 import { BaseGroup } from '../../lib/base-group';
 import { BaseGraphic } from '../../lib/base-graphic';
 import type { IObservation, IProtocolItem } from '@actograph/core';
-import { DisplayModeEnum, ProtocolItemActionEnum } from '@actograph/core';
+import { DisplayModeEnum, ProtocolItemActionEnum, isCategoryVisible } from '@actograph/core';
 import { parseProtocolItems, ProtocolItem } from '../../utils/protocol.utils';
 
 // ============================================================================
@@ -67,11 +67,22 @@ export class YAxis extends BaseGroup {
   private categories: ProtocolItem[] = [];
   private axisStart: IPosition | null = null;
   private axisEnd: IPosition | null = null;
+  /**
+   * Étirement par axe courant (voir PixiApp.axisStretch). Sert uniquement à
+   * contre-scaler les labels pour qu'ils restent lisibles (non déformés) quand
+   * scaleX ≠ scaleY sur le viewport parent. {1,1} = comportement identique à
+   * avant (le zoom uniforme normal continue d'agrandir les labels comme avant).
+   */
+  private axisStretch = { x: 1, y: 1 };
 
   constructor(app: Application) {
     super(app);
     this.graphic = new BaseGraphic(this.app);
     this.addChild(this.graphic);
+  }
+
+  public setAxisStretch(stretch: { x: number; y: number }): void {
+    this.axisStretch = stretch;
   }
 
   public getAxisStart(): IPosition | null {
@@ -354,6 +365,9 @@ export class YAxis extends BaseGroup {
     label.anchor.set(1, 0.5);
     label.visible = true;
     label.alpha = 1;
+    // Contre-scale l'étirement du parent (viewport) pour garder un texte lisible
+    // et non déformé quand scaleX ≠ scaleY (voir PixiApp.axisStretch).
+    label.scale.set(1 / this.axisStretch.x, 1 / this.axisStretch.y);
     this.addChild(label);
     return label;
   }
@@ -379,6 +393,10 @@ export class YAxis extends BaseGroup {
     const reversedCategories = [...this.categories].reverse();
 
     for (const category of reversedCategories) {
+      if (!isCategoryVisible(category)) {
+        continue;
+      }
+
       const displayMode = this.getEffectiveDisplayMode(category);
 
       if (displayMode === DisplayModeEnum.Background) {

--- a/packages/graph/src/pixi-app/data-area/index.ts
+++ b/packages/graph/src/pixi-app/data-area/index.ts
@@ -18,6 +18,7 @@ import {
   TimeDisplayFormatEnum,
   mergeGraphPreferences,
   resolveGraphColor,
+  isCategoryVisible,
 } from '@actograph/core';
 import { YAxis } from '../axis/y-axis';
 import { xAxis } from '../axis/x-axis';
@@ -94,6 +95,15 @@ export class DataArea extends BaseGroup {
   private isDrawInProgress: (() => boolean) | null = null;
   private isAxesGraphicsDirty: (() => boolean) | null = null;
   private requestRender: (() => void) | null = null;
+  /** Voir YAxis.axisStretch : contre-scale marqueurs ronds et étiquette de survol. */
+  private axisStretch = { x: 1, y: 1 };
+
+  public setAxisStretch(stretch: { x: number; y: number }): void {
+    this.axisStretch = stretch;
+    if (this.timeLabelContainer) {
+      this.timeLabelContainer.scale.set(1 / stretch.x, 1 / stretch.y);
+    }
+  }
 
   constructor(
     app: Application,
@@ -550,6 +560,13 @@ export class DataArea extends BaseGroup {
     const normalCategories: Array<{ category: ProtocolItem; readings: IReading[] }> = [];
 
     for (const categoryEntry of this.readingsPerCategory) {
+      if (!isCategoryVisible(categoryEntry.category)) {
+        // Catégorie décochée : ne pas la classer pour dessin, et vider son
+        // graphique persistant pour ne pas laisser un résidu affiché (son
+        // drawCategoryX ne sera pas rappelé tant qu'elle reste cachée).
+        this.clearCategoryGraphic(categoryEntry.category.id);
+        continue;
+      }
       const displayMode = this.getEffectiveDisplayMode(categoryEntry.category);
       if (displayMode === DisplayModeEnum.Background) {
         backgroundCategories.push(categoryEntry);
@@ -688,6 +705,12 @@ export class DataArea extends BaseGroup {
     this.setChildIndex(this.timeLabelContainer!, count - 2);
   }
 
+  /** Vide le graphique persistant d'une catégorie (ex: catégorie décochée), sans le détruire. */
+  private clearCategoryGraphic(categoryId: string): void {
+    const graphicEntry = this.graphicPerCategory.find((g) => g.category.id === categoryId);
+    graphicEntry?.graphic.clear();
+  }
+
   private getOrCreateGraphicForCategory(category: ProtocolItem): BaseGraphic {
     let graphicEntry = this.graphicPerCategory.find((g) => g.category.id === category.id);
     if (!graphicEntry) {
@@ -725,7 +748,14 @@ export class DataArea extends BaseGroup {
           const color = resolveGraphColor(prefs);
           const strokeWidth = prefs?.strokeWidth ?? 4;
 
-          graphic.circle(xPos, yPos, strokeWidth / 2);
+          // Ellipse contre-scalée par l'étirement courant : reste un cercle
+          // visuellement correct même quand scaleX ≠ scaleY sur le viewport.
+          graphic.ellipse(
+            xPos,
+            yPos,
+            strokeWidth / 2 / this.axisStretch.x,
+            strokeWidth / 2 / this.axisStretch.y,
+          );
           graphic.setFillStyle({ color });
           graphic.fill();
         }
@@ -1040,7 +1070,12 @@ export class DataArea extends BaseGroup {
           const color = resolveGraphColor(prefs);
           const strokeWidth = prefs?.strokeWidth ?? 4;
 
-          graphic.circle(xPos, yPos, strokeWidth / 2);
+          graphic.ellipse(
+            xPos,
+            yPos,
+            strokeWidth / 2 / this.axisStretch.x,
+            strokeWidth / 2 / this.axisStretch.y,
+          );
           graphic.setFillStyle({ color });
           graphic.fill();
         }
@@ -1129,6 +1164,11 @@ export class DataArea extends BaseGroup {
       return;
     }
 
+    if (!isCategoryVisible(categoryEntry.category)) {
+      this.clearCategoryGraphic(categoryId);
+      return;
+    }
+
     const displayMode = this.getEffectiveDisplayMode(categoryEntry.category);
 
     switch (displayMode) {
@@ -1177,6 +1217,11 @@ export class DataArea extends BaseGroup {
     const categoryEntry = this.readingsPerCategory.find((r) => r.category.id === category.id);
 
     if (!categoryEntry) {
+      return;
+    }
+
+    if (!isCategoryVisible(categoryEntry.category)) {
+      this.clearCategoryGraphic(category.id);
       return;
     }
 

--- a/packages/graph/src/pixi-app/index.ts
+++ b/packages/graph/src/pixi-app/index.ts
@@ -12,6 +12,7 @@ import {
   computeFitViewport,
   isDegenerateCanvasSize,
   preserveViewportOnResize,
+  type ViewportState,
   type WorldBounds,
 } from '../utils/viewport.utils';
 import type { IGraphRenderOptions } from '../types/graph-render-options';
@@ -71,7 +72,7 @@ export class PixiApp {
    */
   private isInitialized = false;
   private worldBounds: WorldBounds = { width: 1, height: 1 };
-  private fitViewport = { scale: 1, x: 0, y: 0 };
+  private fitViewport: ViewportState = { scaleX: 1, scaleY: 1, x: 0, y: 0 };
   private needsInitialFit = false;
   private pausePeriods: IPeriod[] = [];
   private graphRenderOptions: IGraphRenderOptions = { ...DEFAULT_GRAPH_RENDER_OPTIONS };
@@ -116,6 +117,18 @@ export class PixiApp {
     lastPinchDistance: 0,
     lastPinchCenter: { x: 0, y: 0 },
     isPinching: false,
+  };
+
+  /**
+   * Multiplicateurs d'étirement par axe, appliqués par-dessus zoomState.scale.
+   * Indépendants du zoom pan/molette/+- (qui reste uniforme) : permettent
+   * d'étirer le temps (x) et de compacter les catégories (y) séparément.
+   */
+  private axisStretch = {
+    x: 1,
+    y: 1,
+    minStretch: 0.25,
+    maxStretch: 4,
   };
 
   constructor() {
@@ -268,17 +281,21 @@ export class PixiApp {
       this.recalculateFitViewport();
       const clamped = preserveViewportOnResize(
         {
-          scale: this.zoomState.scale,
+          scaleX: this.zoomState.scale * this.axisStretch.x,
+          scaleY: this.zoomState.scale * this.axisStretch.y,
           x: this.viewport.x,
           y: this.viewport.y,
         },
         this.worldBounds,
         this.getCanvasSize(),
       );
-      this.setViewportTransform(clamped, {
-        emitZoom: false,
-        skipRender: options?.skipRender,
-      });
+      this.setViewportTransform(
+        { scale: this.zoomState.scale, x: clamped.x, y: clamped.y },
+        {
+          emitZoom: false,
+          skipRender: options?.skipRender,
+        },
+      );
     } else if (!options?.skipRender) {
       this.app.render();
     }
@@ -630,7 +647,10 @@ export class PixiApp {
         this.recalculateFitViewport();
         if (this.needsInitialFit) {
           this.needsInitialFit = false;
-          this.setViewportTransform({ ...this.fitViewport }, { skipRender: true });
+          this.setViewportTransform(
+            { scale: this.fitViewport.scaleX, x: this.fitViewport.x, y: this.fitViewport.y },
+            { skipRender: true },
+          );
         } else {
           // Les bornes du plot peuvent avoir changé (protocole, relevés) sans
           // reset volontaire du zoom : on reclamp la vue courante.
@@ -731,10 +751,11 @@ export class PixiApp {
     transform: { scale?: number; x?: number; y?: number },
     options?: { emitZoom?: boolean; skipRender?: boolean },
   ): void {
-    const scale = transform.scale ?? this.zoomState.scale;
+    const baseScale = transform.scale ?? this.zoomState.scale;
     const clamped = clampViewport(
       {
-        scale,
+        scaleX: baseScale * this.axisStretch.x,
+        scaleY: baseScale * this.axisStretch.y,
         x: transform.x ?? this.viewport.x,
         y: transform.y ?? this.viewport.y,
       },
@@ -742,16 +763,16 @@ export class PixiApp {
       this.getCanvasSize(),
     );
 
-    this.zoomState.scale = clamped.scale;
+    this.zoomState.scale = baseScale;
     this.zoomState.x = clamped.x;
     this.zoomState.y = clamped.y;
-    this.viewport.scale.set(clamped.scale);
+    this.viewport.scale.set(clamped.scaleX, clamped.scaleY);
     this.viewport.x = clamped.x;
     this.viewport.y = clamped.y;
     this.updateWorldTransforms();
 
     if (options?.emitZoom !== false) {
-      this.events.emit('zoom', clamped.scale);
+      this.events.emit('zoom', baseScale);
       this.updateTimeScale();
     }
 
@@ -1054,6 +1075,42 @@ export class PixiApp {
   }
 
   /**
+   * Étirement indépendant par axe (x = temps, y = catégories), appliqué
+   * par-dessus le zoom uniforme existant (pan/molette/+-, inchangé).
+   * Redessine les axes/données (labels et marqueurs recréés à chaque draw)
+   * pour que le contre-scaling anti-déformation (voir YAxis/xAxis/DataArea)
+   * soit appliqué avec la nouvelle valeur.
+   */
+  public setAxisStretch(next: { x?: number; y?: number }): Promise<void> {
+    if (typeof next.x === 'number' && Number.isFinite(next.x)) {
+      this.axisStretch.x = Math.max(
+        this.axisStretch.minStretch,
+        Math.min(this.axisStretch.maxStretch, next.x),
+      );
+    }
+    if (typeof next.y === 'number' && Number.isFinite(next.y)) {
+      this.axisStretch.y = Math.max(
+        this.axisStretch.minStretch,
+        Math.min(this.axisStretch.maxStretch, next.y),
+      );
+    }
+
+    const stretch = { x: this.axisStretch.x, y: this.axisStretch.y };
+    this.yAxis.setAxisStretch(stretch);
+    this.xAxis.setAxisStretch(stretch);
+    this.dataArea.setAxisStretch(stretch);
+
+    if (!this.isInteractive) {
+      return Promise.resolve();
+    }
+    return this.draw();
+  }
+
+  public getAxisStretch(): { x: number; y: number } {
+    return { x: this.axisStretch.x, y: this.axisStretch.y };
+  }
+
+  /**
    * Exporte le graphique sous forme d'image (data URL)
    * @param format - Format de l'image : 'png' ou 'jpeg'
    * @param quality - Qualité JPEG (0-1), ignoré pour PNG
@@ -1123,7 +1180,12 @@ export class PixiApp {
           this.zoomState.minScale,
           this.zoomState.maxScale,
         );
-        this.setViewportTransform(fitViewport, { emitZoom: false, skipRender: true });
+        // Applique aussi axisStretch (via setViewportTransform) : l'export
+        // reflète l'étirement courant, comme ce que l'utilisatrice voit à l'écran.
+        this.setViewportTransform(
+          { scale: fitViewport.scaleX, x: fitViewport.x, y: fitViewport.y },
+          { emitZoom: false, skipRender: true },
+        );
       }
 
       // Direct enqueue (not draw()): avoids deadlock with external draws that

--- a/packages/graph/src/utils/viewport.utils.ts
+++ b/packages/graph/src/utils/viewport.utils.ts
@@ -1,7 +1,10 @@
 export interface ViewportState {
   x: number;
   y: number;
-  scale: number;
+  /** Échelle horizontale (temps). Distincte de scaleY pour permettre l'étirement de l'axe X indépendamment. */
+  scaleX: number;
+  /** Échelle verticale (catégories). Distincte de scaleX pour permettre la compaction de l'axe Y indépendamment. */
+  scaleY: number;
 }
 
 export interface WorldBounds {
@@ -22,8 +25,10 @@ export function isDegenerateCanvasSize(width: number, height: number): boolean {
 }
 
 /**
- * Scale initial pour faire tenir le plot entier dans le canvas (mode interactif).
+ * Scale initial (uniforme) pour faire tenir le plot entier dans le canvas (mode interactif).
  * Ne zoome pas au-delà de 1 si le contenu est déjà plus petit que le canvas.
+ * Reste volontairement une échelle unique : c'est la base du zoom pan/molette/+- ;
+ * l'étirement par axe (axisStretch) est composé par-dessus par l'appelant.
  */
 export function computeFitScale(
   worldBounds: WorldBounds,
@@ -48,10 +53,11 @@ export function computeFitScale(
 export function computeFitViewportPosition(
   worldBounds: WorldBounds,
   canvasSize: CanvasSize,
-  scale: number,
+  scaleX: number,
+  scaleY: number,
 ): { x: number; y: number } {
-  const scaledWidth = worldBounds.width * scale;
-  const scaledHeight = worldBounds.height * scale;
+  const scaledWidth = worldBounds.width * scaleX;
+  const scaledHeight = worldBounds.height * scaleY;
 
   const x = scaledWidth < canvasSize.width ? (canvasSize.width - scaledWidth) / 2 : 0;
   const y = scaledHeight < canvasSize.height ? (canvasSize.height - scaledHeight) / 2 : 0;
@@ -61,6 +67,7 @@ export function computeFitViewportPosition(
 
 /**
  * Borne le viewport pour éviter de montrer une zone vide hors du plot.
+ * scaleX/scaleY sont bornés indépendamment (largeur contre scaleX, hauteur contre scaleY).
  */
 export function clampViewport(
   viewport: ViewportState,
@@ -68,9 +75,9 @@ export function clampViewport(
   canvasSize: CanvasSize,
   margin = DEFAULT_OVERSCROLL_MARGIN,
 ): ViewportState {
-  const { scale } = viewport;
-  const scaledWidth = worldBounds.width * scale;
-  const scaledHeight = worldBounds.height * scale;
+  const { scaleX, scaleY } = viewport;
+  const scaledWidth = worldBounds.width * scaleX;
+  const scaledHeight = worldBounds.height * scaleY;
 
   let x = viewport.x;
   let y = viewport.y;
@@ -91,11 +98,13 @@ export function clampViewport(
     y = Math.max(minY, Math.min(maxY, y));
   }
 
-  return { x, y, scale };
+  return { x, y, scaleX, scaleY };
 }
 
 /**
  * Fit viewport for a given world size and canvas (used on init, export, resize).
+ * Le fit reste uniforme (scaleX === scaleY) : c'est la base neutre avant application
+ * de l'étirement par axe par l'appelant (PixiApp.axisStretch).
  */
 export function computeFitViewport(
   worldBounds: WorldBounds,
@@ -104,8 +113,8 @@ export function computeFitViewport(
   maxScale: number,
 ): ViewportState {
   const scale = computeFitScale(worldBounds, canvasSize, minScale, maxScale);
-  const position = computeFitViewportPosition(worldBounds, canvasSize, scale);
-  return { scale, x: position.x, y: position.y };
+  const position = computeFitViewportPosition(worldBounds, canvasSize, scale, scale);
+  return { scaleX: scale, scaleY: scale, x: position.x, y: position.y };
 }
 
 /**


### PR DESCRIPTION
## Résumé

Deux réglages d'affichage pour le graphe d'activité, demandés pour améliorer la lisibilité des chroniques chargées (beaucoup de catégories / longue durée) :

- **Étirement indépendant des axes** : nouveau menu "Ajuster l'affichage" (icône réglages) dans le bandeau du graphe, avec deux sliders — étirer l'axe du temps et compacter la hauteur des catégories, indépendamment l'un de l'autre et par-dessus le zoom uniforme existant (+/-, molette, inchangés). Un bouton "Réinitialiser" remet les deux à 1×. Un contre-scaling a été ajouté pour les textes et les marqueurs de relevés discrets afin qu'ils ne se déforment pas quand les deux axes ont une échelle différente.
- **Visibilité des catégories** : case à cocher par catégorie dans le volet de personnalisation (à droite du graphe) pour la retirer/remettre à l'affichage. Les catégories suivantes remontent automatiquement pour combler le vide, comme pour le mode "Arrière-plan" existant. La légende exportée est cohérente avec ce qui est masqué.

Les deux réglages sont persistés par chronique (`observation.meta.graphXStretch`/`graphYCompact` pour le premier, `graphPreferences.visible` pour le second, sur le même circuit que les préférences de couleur/motif existantes).

## Vérification

- `vue-tsc` : 0 erreur
- Vérifié dans le navigateur : cases à cocher (décochage/recochage, compaction, absence de résidu graphique, persistance après rechargement, export de légende), et sliders d'étirement (valeurs, persistance après rechargement, réinitialisation, absence d'erreur console) — confirmé par inspection directe de l'état du composant, la capture d'écran visuelle n'ayant pas été possible dans l'environnement de prévisualisation utilisé.

🤖 Généré avec [Claude Code](https://claude.com/claude-code)