### PR TITLE
fix(observation): pause en mode chronomètre + indicateur visuel

### DIFF
--- a/front/src/i18n/en-US/index.ts
+++ b/front/src/i18n/en-US/index.ts
@@ -185,6 +185,9 @@ export default {
     readyState: 'Ready',
     tooltipSwitchToCalendar: 'Switch to calendar mode',
     tooltipSwitchToChronometer: 'Switch to chronometer mode',
+    pausedBadge: 'Paused',
+    pausedOverlayTitle: 'Paused',
+    pausedOverlaySubtitle: 'Readings locked until resumed',
     noProtocolLoadedTitle: 'No protocol loaded',
     noProtocolLoadedHint:
       'Select an observation to display its protocol.',
@@ -492,6 +495,12 @@ export default {
     timeFormatMinuteSecond: 'mm:ss',
     timeFormatSecond: 'sec',
     timeFormatMinuteSecondMs: 'mm:ss:ms',
+    toggleCategoryVisibility: 'Show/hide this category on the graph',
+    axisScaleTooltip: 'Adjust display',
+    axisScaleTitle: 'Adjust display',
+    axisScaleXLabel: 'Stretch time axis',
+    axisScaleYLabel: 'Compact categories',
+    axisScaleReset: 'Reset',
   },
   appRoot: {
     updateAvailableTitle: 'Update available',

--- a/front/src/i18n/en-US/index.ts
+++ b/front/src/i18n/en-US/index.ts
@@ -495,12 +495,6 @@ export default {
     timeFormatMinuteSecond: 'mm:ss',
     timeFormatSecond: 'sec',
     timeFormatMinuteSecondMs: 'mm:ss:ms',
-    toggleCategoryVisibility: 'Show/hide this category on the graph',
-    axisScaleTooltip: 'Adjust display',
-    axisScaleTitle: 'Adjust display',
-    axisScaleXLabel: 'Stretch time axis',
-    axisScaleYLabel: 'Compact categories',
-    axisScaleReset: 'Reset',
   },
   appRoot: {
     updateAvailableTitle: 'Update available',

--- a/front/src/i18n/fr/index.ts
+++ b/front/src/i18n/fr/index.ts
@@ -502,12 +502,6 @@ export default {
     timeFormatMinuteSecond: 'mn:sec',
     timeFormatSecond: 'sec',
     timeFormatMinuteSecondMs: 'mn:sec:ms',
-    toggleCategoryVisibility: 'Afficher/masquer cette catégorie sur le graphe',
-    axisScaleTooltip: 'Ajuster l\'affichage',
-    axisScaleTitle: 'Ajuster l\'affichage',
-    axisScaleXLabel: 'Étirer l\'axe du temps',
-    axisScaleYLabel: 'Compacter les catégories',
-    axisScaleReset: 'Réinitialiser',
   },
   appRoot: {
     updateAvailableTitle: 'Mise à jour disponible',

--- a/front/src/i18n/fr/index.ts
+++ b/front/src/i18n/fr/index.ts
@@ -188,6 +188,9 @@ export default {
     readyState: 'Prêt',
     tooltipSwitchToCalendar: 'Passer en mode calendrier',
     tooltipSwitchToChronometer: 'Passer en mode chronomètre',
+    pausedBadge: 'En pause',
+    pausedOverlayTitle: 'En pause',
+    pausedOverlaySubtitle: 'Relevés verrouillés jusqu\'à la reprise',
     noProtocolLoadedTitle: 'Aucun protocole chargé',
     noProtocolLoadedHint:
       'Veuillez sélectionner une observation pour afficher son protocole.',
@@ -499,6 +502,12 @@ export default {
     timeFormatMinuteSecond: 'mn:sec',
     timeFormatSecond: 'sec',
     timeFormatMinuteSecondMs: 'mn:sec:ms',
+    toggleCategoryVisibility: 'Afficher/masquer cette catégorie sur le graphe',
+    axisScaleTooltip: 'Ajuster l\'affichage',
+    axisScaleTitle: 'Ajuster l\'affichage',
+    axisScaleXLabel: 'Étirer l\'axe du temps',
+    axisScaleYLabel: 'Compacter les catégories',
+    axisScaleReset: 'Réinitialiser',
   },
   appRoot: {
     updateAvailableTitle: 'Mise à jour disponible',

--- a/front/src/pages/userspace/observation/_components/CalendarToolbar.vue
+++ b/front/src/pages/userspace/observation/_components/CalendarToolbar.vue
@@ -20,6 +20,18 @@
       @click="handleStop"
     />
 
+    <!-- Paused indicator: distinct color from the play (resume) and stop
+         buttons, so the operator recognizes at a glance that readings are
+         locked, without confusing it with the button used to resume. -->
+    <q-chip
+      v-if="isPausedState"
+      class="paused-badge"
+      icon="lock"
+      dense
+    >
+      {{ $t('observation.pausedBadge') }}
+    </q-chip>
+
     <!-- Attach video (chronometer without video) -->
     <q-btn
       v-if="showAttachVideo"
@@ -105,6 +117,13 @@ export default defineComponent({
     const isObservationActive = computed(() => {
       return observation.sharedState.isPlaying
         || observation.sharedState.elapsedTime > 0;
+    });
+
+    // Observation démarrée (ou déjà avancée) mais actuellement à l'arrêt :
+    // affiche le badge "En pause" pour donner un retour visuel non ambigu,
+    // distinct de la couleur du bouton lecture (bleu, "reprendre").
+    const isPausedState = computed(() => {
+      return !observation.sharedState.isPlaying && isObservationActive.value;
     });
 
     // Attacher une vidéo alors que le chrono a déjà avancé bascule usesVideoTime
@@ -208,6 +227,7 @@ export default defineComponent({
       currentMode,
       canChangeMode,
       isObservationActive,
+      isPausedState,
       attachInProgress,
       showAttachVideo,
       attachVideoBlocked,
@@ -228,6 +248,20 @@ export default defineComponent({
   flex-shrink: 0;
   min-height: 0;
   height: auto;
+}
+
+/* Badge "En pause" : ambre, volontairement distinct du bleu (bouton lecture
+   / reprendre) et du rouge (bouton pause pendant l'enregistrement actif),
+   pour ne jamais être confondu avec la couleur habituelle de reprise. */
+.paused-badge {
+  background-color: #fac775 !important;
+  color: #412402 !important;
+  font-weight: 500;
+}
+
+.body--dark .paused-badge {
+  background-color: #854f0b !important;
+  color: #faeeda !important;
 }
 </style>
 

--- a/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
+++ b/front/src/pages/userspace/observation/_components/buttons-side/Index.vue
@@ -54,7 +54,17 @@
       </div>
     </div>
 
-    <DScrollArea class="col" style="min-height: 0;">
+    <div class="col buttons-scroll-wrapper position-relative" style="min-height: 0;">
+      <!-- Voile "En pause" : uniquement en mode calendrier, quand la pause
+           verrouille les relevés. Renforce visuellement que les boutons ci-
+           dessous sont désactivés (isContinuousDisabled/isDiscreteDisabled). -->
+      <div v-if="computedState.isLockedByCalendarPause.value" class="paused-overlay column items-center justify-center">
+        <q-icon name="lock" size="24px" />
+        <div class="paused-overlay-title q-mt-xs">{{ $t('observation.pausedOverlayTitle') }}</div>
+        <div class="paused-overlay-subtitle">{{ $t('observation.pausedOverlaySubtitle') }}</div>
+      </div>
+
+      <DScrollArea class="fit" style="min-height: 0;">
       <div class="categories-wrapper"
         ref="categoriesWrapper"
         :style="{ '--ui-scale': state.uiScale }"
@@ -86,6 +96,7 @@
         </div>
       </div>
     </DScrollArea>
+    </div>
   </div>
 </template>
 
@@ -201,18 +212,33 @@ export default defineComponent({
       isRecordingActiveFromReadings(readings.sharedState.currentReadings)
     );
 
-    const canRecordReading = computed(
-      () => isRecordingStarted.value && observation.sharedState.isPlaying
+    const isPaused = computed(() => isRecordingStarted.value && !observation.sharedState.isPlaying);
+
+    // En mode chronomètre (avec ou sans vidéo), la pause fige le temps mais les
+    // boutons restent actifs : les relevés doivent pouvoir s'enregistrer au temps
+    // figé, exactement comme en mode vidéo où la vidéo à l'arrêt reste cliquable.
+    // En mode calendrier (observation in situ), la pause verrouille les relevés :
+    // impossible d'enregistrer tant que l'observation n'a pas repris.
+    const canRecordReading = computed(() => {
+      if (!isRecordingStarted.value) return false;
+      if (observation.isChronometerMode.value) return true;
+      return observation.sharedState.isPlaying;
+    });
+
+    // Les boutons ne sont verrouillés (grisés) qu'en mode calendrier pendant une
+    // pause. Dans tous les autres cas (mode chronomètre, avant le START, en
+    // lecture) ils restent utilisables (Bug 2.3 / 2.4).
+    const isLockedByCalendarPause = computed(
+      () => isPaused.value && !observation.isChronometerMode.value
     );
 
     const computedState = {
       isRecordingStarted,
-      isPaused: computed(() => isRecordingStarted.value && !observation.sharedState.isPlaying),
+      isPaused,
       canRecordReading,
-      // Bug 2.3 / 2.4: les boutons doivent rester utilisables
-      // même sans START explicite et en pause.
-      isContinuousDisabled: computed(() => false),
-      isDiscreteDisabled: computed(() => false),
+      isLockedByCalendarPause,
+      isContinuousDisabled: computed(() => isLockedByCalendarPause.value),
+      isDiscreteDisabled: computed(() => isLockedByCalendarPause.value),
       categories: computed(() => {
         if (!sharedState.currentProtocol || !sharedState.currentProtocol._items) {
           return [] as ProtocolItem[];
@@ -964,6 +990,39 @@ export default defineComponent({
 </script>
 
 <style scoped>
+/* Voile "En pause" (mode calendrier uniquement) : mêmes couleurs que le badge
+   de CalendarToolbar (ambre), pour un signal visuel cohérent et distinct du
+   bleu (reprendre) / rouge (pause pendant l'enregistrement actif). */
+.paused-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  background-color: rgba(252, 252, 252, 0.82);
+  backdrop-filter: blur(1px);
+  color: #854f0b;
+  text-align: center;
+  pointer-events: none;
+}
+
+.body--dark .paused-overlay {
+  background-color: rgba(20, 26, 36, 0.82);
+  color: #faeeda;
+}
+
+.paused-overlay-title {
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.paused-overlay-subtitle {
+  font-size: 13px;
+  color: var(--text-secondary, #666);
+}
+
+.body--dark .paused-overlay-subtitle {
+  color: rgba(255, 255, 255, 0.75);
+}
+
 .buttons-side-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Résumé

- **Bug** : en mode chronomètre (avec ou sans vidéo), cliquer sur Pause figeait bien le temps mais bloquait aussi l'enregistrement des relevés (`canRecordReading` exigeait `isPlaying` dans tous les modes), alors que les boutons restaient affichés comme cliquables — comportement trompeur, contraire au commentaire "Bug 2.3/2.4" du code lui-même. Corrigé pour que, comme en mode vidéo, les boutons restent actifs et enregistrent au temps figé en mode chronomètre pendant la pause.
- **Mode calendrier** (in situ) : comportement inchangé sur le fond (la pause verrouille les relevés), mais désormais les boutons sont réellement désactivés visuellement pendant la pause (ils restaient cliquables sans effet auparavant).
- **Retour visuel** : ajout d'un indicateur "En pause" sans ambiguïté — badge ambre à côté des boutons lecture/stop, et voile + étiquette centrale sur le panneau de boutons en mode calendrier. Couleur ambre choisie pour ne jamais se confondre avec le bleu (reprendre) ou le rouge (pause pendant l'enregistrement actif).

## Fichiers modifiés

- `front/src/pages/userspace/observation/_components/buttons-side/Index.vue` — logique `canRecordReading` / `isContinuousDisabled` / `isDiscreteDisabled` par mode, voile "En pause"
- `front/src/pages/userspace/observation/_components/CalendarToolbar.vue` — badge "En pause"
- `front/src/i18n/fr/index.ts`, `front/src/i18n/en-US/index.ts` — clés de traduction

## Test plan

- [ ] Mode chronomètre sans vidéo : démarrer, mettre en pause, vérifier que le chrono se fige, que le badge "En pause" apparaît, et que cliquer un bouton observable enregistre bien un relevé au temps figé
- [ ] Mode chronomètre avec vidéo : vérifier que le comportement (déjà correct) est inchangé
- [ ] Mode calendrier : démarrer, mettre en pause, vérifier que les boutons sont grisés/non cliquables, que le badge + voile "En pause" apparaissent, et qu'aucun relevé ne s'enregistre
- [ ] Reprendre après pause dans les trois modes : vérifier que tout redevient normal (badge disparaît, boutons réactivés)
- [ ] `yarn lint` / `yarn typecheck` sur `front` (déjà validés localement, aucune erreur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)