### PR TITLE
fix: labels d'axe X obliques dans le graphique d'occurrences des stats

### DIFF
--- a/front/src/pages/userspace/statistics/_components/AmChartsBarChart.vue
+++ b/front/src/pages/userspace/statistics/_components/AmChartsBarChart.vue
@@ -141,9 +141,26 @@ export default defineComponent({
           renderer: am5xy.AxisRendererX.new(root, {
             cellStartLocation: 0.1,
             cellEndLocation: 0.9,
+            // Petite distance minimale car les labels sont inclinés (moins
+            // d'emprise horizontale) : la valeur par défaut (50) forçait
+            // amCharts à faire chevaucher/masquer des labels de catégories
+            // dès qu'il y en avait plus de 5-6 sur des largeurs de carte
+            // courantes.
+            minGridDistance: 10,
           }),
         })
       );
+
+      // Labels obliques : évite le chevauchement entre noms de catégories
+      // longs (ex. "Hangar Autres" / "Alcôves") qui, à l'horizontale,
+      // finissaient superposés et illisibles sur des largeurs de carte
+      // courantes.
+      xAxis.get('renderer').labels.template.setAll({
+        rotation: -45,
+        centerY: am5.p50,
+        centerX: am5.p100,
+        paddingRight: 15,
+      });
 
       // Create Y axis (values) - pour barres verticales
       const yAxis = chart.yAxes.push(


### PR DESCRIPTION
## Contexte

Dans les statistiques (mode simple par catégorie **et** mode avancé, qui partagent le même composant), le graphique "Nombre d'occurrences" affichait des labels d'axe X à l'horizontale qui se chevauchaient et devenaient illisibles dès qu'il y avait plus de 5-6 catégories avec des noms un peu longs (ex. "Hangar Autres", "Alcôves").

## Correctif

- Passage des labels de l'axe X en oblique (-45°) dans `AmChartsBarChart.vue`, avec un `minGridDistance` réduit (chaque label ayant une emprise horizontale plus faible une fois incliné).
- Vérifié (repro isolée + inspection pixel de l'export) que l'export PNG/JPEG via le plugin Exporting n'coupe pas ces labels inclinés.

## Test plan

- [x] Repro isolée du bug de chevauchement (amCharts5, 9 catégories, largeur réduite) confirmant le chevauchement avant / la lisibilité après.
- [x] Vérification pixel-par-pixel que l'export PNG ne coupe pas les labels obliques.
- [x] `vue-tsc --noEmit` passe sans erreur.
- [ ] Test manuel dans l'app par Sylvain sur une observation réelle avec plusieurs catégories.

Note : le bug du graphique du mode avancé (axe des ordonnées négatif + graphique vide) reste à traiter séparément, ce n'est pas inclus dans cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)