### PR TITLE
fix(statistiques): histogramme d'occurrences vide et axe negatif en mode avance

### DIFF
--- a/front/src/pages/userspace/statistics/_components/AmChartsBarChart.vue
+++ b/front/src/pages/userspace/statistics/_components/AmChartsBarChart.vue
@@ -146,8 +146,11 @@ export default defineComponent({
       );
 
       // Create Y axis (values) - pour barres verticales
+      // min: 0 because these values are occurrence counts, which are never negative;
+      // without it amCharts pads a lone zero value with an arbitrary negative range.
       const yAxis = chart.yAxes.push(
         am5xy.ValueAxis.new(root, {
+          min: 0,
           ...(props.integerAxis ? { maxPrecision: 0 } : {}),
           renderer: am5xy.AxisRendererY.new(root, {}),
         })

--- a/packages/core/src/__tests__/statistics/conditional-statistics.test.ts
+++ b/packages/core/src/__tests__/statistics/conditional-statistics.test.ts
@@ -709,6 +709,78 @@ describe('conditional-statistics', () => {
     expect(t?.onDuration).toBe(5 * 60 * 1000);
   });
 
+  it('counts an occurrence when the target observable is already active before the condition turns on', () => {
+    // Common real-world pattern: the target (e.g. a location) activates first,
+    // and the condition observable (e.g. an unrelated activity) only turns on
+    // later while the location is still active. The location's activation
+    // reading therefore falls BEFORE the condition-filtered window starts,
+    // but this must still count as one occurrence, not zero.
+    const multiCategoryProtocol: IProtocolItem[] = [
+      {
+        id: 'loc',
+        type: ProtocolItemTypeEnum.Category,
+        name: 'Loc',
+        children: [
+          { id: 'bureau', type: ProtocolItemTypeEnum.Observable, name: 'Bureau' },
+          { id: 'hangar', type: ProtocolItemTypeEnum.Observable, name: 'Hangar' },
+        ],
+      },
+      {
+        id: 'ali',
+        type: ProtocolItemTypeEnum.Category,
+        name: 'Ali',
+        children: [{ id: 'e', type: ProtocolItemTypeEnum.Observable, name: 'Eat' }],
+      },
+    ];
+
+    const readingsForCount: IReading[] = [
+      {
+        type: ReadingTypeEnum.START,
+        dateTime: new Date('2024-01-01T10:00:00.000Z'),
+      },
+      {
+        type: ReadingTypeEnum.DATA,
+        dateTime: new Date('2024-01-01T10:01:00.000Z'),
+        name: 'Bureau',
+      },
+      {
+        type: ReadingTypeEnum.DATA,
+        dateTime: new Date('2024-01-01T10:05:00.000Z'),
+        name: 'Eat',
+      },
+      {
+        type: ReadingTypeEnum.DATA,
+        dateTime: new Date('2024-01-01T10:08:00.000Z'),
+        name: 'Hangar',
+      },
+      {
+        type: ReadingTypeEnum.STOP,
+        dateTime: new Date('2024-01-01T10:10:00.000Z'),
+      },
+    ];
+
+    const result = calculateConditionalStatistics(
+      readingsForCount,
+      multiCategoryProtocol,
+      {
+        targetCategoryId: 'loc',
+        groupOperator: ConditionOperatorEnum.OR,
+        conditionGroups: [
+          {
+            operator: ConditionOperatorEnum.OR,
+            observables: [{ observableName: 'Eat', state: ObservableStateEnum.ON }],
+          },
+        ],
+      },
+    );
+
+    const bureau = result.categoryStatistics.observables.find(
+      (obs) => obs.observableName === 'Bureau',
+    );
+    expect(bureau?.onCount).toBe(1);
+    expect(bureau?.onDuration).toBe(3 * 60 * 1000);
+  });
+
   it('supports discrete target categories with occurrence counts only', () => {
     const discreteProtocol: IProtocolItem[] = [
       {

--- a/packages/core/src/statistics/conditional-statistics.ts
+++ b/packages/core/src/statistics/conditional-statistics.ts
@@ -18,6 +18,7 @@ import {
   calculatePausePeriods,
   calculatePauseOverlap,
   intersectPeriods,
+  intersectTwoPeriods,
   unionPeriods,
   filterByTimeRange,
   subtractPausesFromPeriods,
@@ -298,11 +299,15 @@ export function calculateCategoryStatisticsForPeriods(
         return sum + Math.max(0, rawDuration - pauseOverlap);
       }, 0);
 
-      const onCount = countObservableActivationsInPeriods(
-        readings,
-        observableName,
-        filteredObservablePeriods,
-      );
+      // Count distinct "on" episodes that overlap the filtered window at all,
+      // rather than raw activation readings landing inside it: the reading
+      // that starts an episode predates the window whenever the observable
+      // was already active before a condition turned on, which would
+      // otherwise undercount (down to zero) the very common case where the
+      // target observable activates first and the condition follows.
+      const onCount = observablePeriods.filter((period) =>
+        periods.some((filterPeriod) => intersectTwoPeriods(period, filterPeriod) !== null),
+      ).length;
 
       return {
         observableId: observable.id,


### PR DESCRIPTION
## Résumé
- Le comptage d'occurrences du mode statistiques avancées ne comptait que les relevés d'activation tombant à l'intérieur de la fenêtre filtrée par les conditions. Quand l'observable cible s'active avant que la condition ne devienne vraie (cas courant : ex. une catégorie "lieu" déjà active quand une autre condition se déclenche plus tard), son relevé tombait avant le début de la fenêtre et n'était jamais compté — vidant complètement l'histogramme d'occurrences alors que le camembert (basé sur les durées) restait correct.
- Le comptage se base désormais sur les épisodes actifs qui *chevauchent* la fenêtre filtrée plutôt que sur les seuls relevés qui y tombent, ce qui corrige le cas signalé sans régresser le test existant qui évite de sur-compter un même épisode fragmenté par des conditions OR intermittentes.
- L'axe Y de l'histogramme force aussi `min: 0` : ces valeurs sont toujours des comptes d'occurrences (jamais négatifs). Sans cela, amCharts affichait une plage arbitraire (-1 à 1) quand le graphique était vide.

## Test plan
- [x] `packages/core`: `npx jest conditional-statistics category-statistics` → 22/22 tests passent, y compris un nouveau test reproduisant le bug signalé (observable cible actif avant que la condition ne se déclenche).
- [ ] Vérification manuelle dans l'app : charger une observation, passer en mode statistiques avancées, définir une catégorie cible + condition, vérifier que l'histogramme affiche les occurrences et que l'axe Y ne descend jamais sous 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)