### PR TITLE
fix(graph): isoler les graduations/frises de l'étirement d'axe (suite PR #101)

### DIFF
--- a/packages/graph/src/pixi-app/axis/y-axis.ts
+++ b/packages/graph/src/pixi-app/axis/y-axis.ts
@@ -327,8 +327,12 @@ export class YAxis extends BaseGroup {
   }
 
   private drawNormalTick(axisX: number, tickY: number, label: string): void {
-    this.graphic.moveTo(axisX - TICK_CONFIG.TICK_LENGTH, tickY);
-    this.graphic.lineTo(axisX + TICK_CONFIG.TICK_LENGTH, tickY);
+    // Contre-scale l'étirement horizontal (temps) : une graduation est une
+    // marque de repère fixe, elle ne doit pas s'allonger/raccourcir quand
+    // l'utilisatrice étire l'axe du temps (voir PixiApp.axisStretch).
+    const tickLength = TICK_CONFIG.TICK_LENGTH / this.axisStretch.x;
+    this.graphic.moveTo(axisX - tickLength, tickY);
+    this.graphic.lineTo(axisX + tickLength, tickY);
     this.graphic.setStrokeStyle({
       color: TICK_CONFIG.COLOR,
       width: TICK_CONFIG.TICK_WIDTH,
@@ -339,8 +343,9 @@ export class YAxis extends BaseGroup {
   }
 
   private drawFriezeTick(axisX: number, tickY: number, label: string): void {
-    this.graphic.moveTo(axisX - TICK_CONFIG.FRIEZE_TICK_LENGTH, tickY);
-    this.graphic.lineTo(axisX + TICK_CONFIG.FRIEZE_TICK_LENGTH, tickY);
+    const tickLength = TICK_CONFIG.FRIEZE_TICK_LENGTH / this.axisStretch.x;
+    this.graphic.moveTo(axisX - tickLength, tickY);
+    this.graphic.lineTo(axisX + tickLength, tickY);
     this.graphic.setStrokeStyle({
       color: TICK_CONFIG.COLOR,
       width: TICK_CONFIG.TICK_WIDTH,
@@ -408,16 +413,21 @@ export class YAxis extends BaseGroup {
       }
 
       if (displayMode === DisplayModeEnum.Frieze) {
+        // Contre-scale la compaction verticale : une frise garde une hauteur
+        // affichée fixe même quand l'utilisatrice compacte l'axe Y (voir
+        // PixiApp.axisStretch), contrairement aux lignes d'observables
+        // normales qui doivent se compacter.
+        const worldFriezeHeight = TICK_CONFIG.FRIEZE_HEIGHT / this.axisStretch.y;
         const friezeStartY = axisLength;
-        axisLength += TICK_CONFIG.FRIEZE_HEIGHT;
+        axisLength += worldFriezeHeight;
 
         ticks.push({
           label: category.name,
-          pos: friezeStartY + TICK_CONFIG.FRIEZE_HEIGHT / 2,
+          pos: friezeStartY + worldFriezeHeight / 2,
           category,
           observable: category,
           isFrieze: true,
-          friezeHeight: TICK_CONFIG.FRIEZE_HEIGHT,
+          friezeHeight: worldFriezeHeight,
           friezeStartY,
         });
       } else {

--- a/packages/graph/src/pixi-app/data-area/index.ts
+++ b/packages/graph/src/pixi-app/data-area/index.ts
@@ -858,7 +858,12 @@ export class DataArea extends BaseGroup {
           graphic.lineTo(xPos, yPos);
           graphic.setStrokeStyle({
             color: 'grey',
-            width: 1,
+            // Contre-scale l'étirement horizontal : l'épaisseur d'une ligne
+            // verticale est portée par scaleX, donc étirer l'axe du temps la
+            // ferait paraître plus épaisse/fine sans raison (voir
+            // PixiApp.axisStretch, même logique que les marqueurs ellipse
+            // ci-dessus).
+            width: 1 / this.axisStretch.x,
           });
           graphic.stroke();
         }


### PR DESCRIPTION
## Contexte

Suite à la PR #101 (étirement indépendant des axes X/Y), Valérie a remonté 2 bugs de rendu dans le graphe.

## Bugs corrigés

1. **L'étirement de l'axe du temps ne devrait pas étirer les graduations de l'axe Y**
   Les petits traits de graduation de l'axe Y sont des lignes horizontales dessinées dans le même conteneur que le viewport, qui a désormais une échelle anisotrope (`scaleX ≠ scaleY`). Leur longueur suivait `scaleX` : étirer l'axe du temps les allongeait/raccourcissait visuellement. Fix : longueur contre-scalée par `1/axisStretch.x` (`packages/graph/src/pixi-app/axis/y-axis.ts`).

2. **L'étirement de l'axe du temps ne devrait pas étirer les lignes verticales qui relient les états continus**
   Même cause : l'épaisseur du trait vertical qui relie deux états dans une catégorie continue suit `scaleX` (le trait est vertical, donc son épaisseur est portée par l'axe horizontal). Fix : épaisseur contre-scalée par `1/axisStretch.x` (`packages/graph/src/pixi-app/data-area/index.ts`).

3. **Le compactage de l'axe Y ne devrait pas compacter les frises, qui doivent rester de même hauteur**
   La hauteur allouée à une frise (`FRIEZE_HEIGHT`) n'était pas compensée quand on compacte l'axe Y (`axisStretch.y < 1`), donc les frises rétrécissaient comme les lignes normales. Fix : hauteur monde de la frise = `FRIEZE_HEIGHT / axisStretch.y`, ce qui annule exactement la compaction pour cet élément tout en la laissant s'appliquer normalement aux catégories classiques (`packages/graph/src/pixi-app/axis/y-axis.ts`).

Les 3 correctifs suivent le même principe de contre-scalage déjà utilisé dans la PR #101 pour les labels et les marqueurs ronds (ellipses des observables ponctuels), qui n'avait pas été étendu à ces 3 éléments.

## Vérification

- Type-check du package `graph` : OK.
- Suite de tests existante (`yarn test` dans `packages/graph`) : 77 tests passants, aucune régression.
- Vérification visuelle non concluante : le pane de navigateur sandboxé utilisé pour la vérification reste en `document.visibilityState: hidden`, ce qui bloque le rendu du graphe (garde `requestAnimationFrame`) indépendamment du code. À vérifier visuellement côté Sylvain/testeurs.

🤖 Généré avec [Claude Code](https://claude.com/claude-code)