### PR TITLE
fix(observation): heure réelle et voile de pause en mode calendrier

### DIFF
--- a/front/src/composables/use-observation/index.ts
+++ b/front/src/composables/use-observation/index.ts
@@ -149,14 +149,22 @@ export const useObservation = (options?: { init?: boolean }) => {
 
       const now = Date.now();
 
-      if (!sharedState.startTime) {
-        if (isChronometerMode.value) {
+      // Mode calendrier : currentDate doit toujours refléter l'heure réelle
+      // actuelle au (re)démarrage, y compris à la reprise après une pause.
+      // Sans ce `else` inconditionnel, startTime restait non-null après une
+      // pause (seul stopTimer le remet à null) et ce bloc ne s'exécutait
+      // qu'au tout premier démarrage : la reprise réutilisait alors le
+      // currentDate figé au moment de la mise en pause, et le relevé
+      // "fin de pause" (ajouté juste après avec ce currentDate) enregistrait
+      // l'heure de la pause au lieu de l'heure de reprise.
+      if (isChronometerMode.value) {
+        if (!sharedState.startTime) {
           const t0 = chronometerMethods.getT0();
           const elapsedMs = sharedState.elapsedTime * 1000;
           sharedState.currentDate = new Date(t0.getTime() + elapsedMs);
-        } else {
-          sharedState.currentDate = new Date();
         }
+      } else {
+        sharedState.currentDate = new Date(now);
       }
 
       sharedState.startTime = now - sharedState.elapsedTime * 1000;

--- a/front/src/composables/use-observation/index.ts
+++ b/front/src/composables/use-observation/index.ts
@@ -137,26 +137,16 @@ export const useObservation = (options?: { init?: boolean }) => {
     startTimer: () => {
       if (sharedState.isPlaying) return;
 
-      const shouldCreateStartReading = !isRecordingActiveFromReadings(
-        readings.sharedState.currentReadings,
-      );
-
-      if (shouldCreateStartReading) {
-        readings.methods.addStartReading();
-      } else {
-        readings.methods.addPauseEndReading();
-      }
-
       const now = Date.now();
 
-      // Mode calendrier : currentDate doit toujours refléter l'heure réelle
-      // actuelle au (re)démarrage, y compris à la reprise après une pause.
-      // Sans ce `else` inconditionnel, startTime restait non-null après une
-      // pause (seul stopTimer le remet à null) et ce bloc ne s'exécutait
-      // qu'au tout premier démarrage : la reprise réutilisait alors le
-      // currentDate figé au moment de la mise en pause, et le relevé
-      // "fin de pause" (ajouté juste après avec ce currentDate) enregistrait
-      // l'heure de la pause au lieu de l'heure de reprise.
+      // currentDate DOIT être à jour AVANT addStartReading / addPauseEndReading :
+      // ces méthodes lisent sharedState.currentDate pour horodater le relevé.
+      // Mode calendrier : toujours l'heure murale réelle au (re)démarrage, y
+      // compris à la reprise après pause (sinon le relevé "fin de pause"
+      // réutilise le currentDate figé à la mise en pause).
+      // Mode chronomètre : ne recalcule qu'au premier démarrage (startTime
+      // null) ; à la reprise, elapsed et currentDate restent cohérents car
+      // le temps chronomètre ne avance pas pendant la pause.
       if (isChronometerMode.value) {
         if (!sharedState.startTime) {
           const t0 = chronometerMethods.getT0();
@@ -165,6 +155,16 @@ export const useObservation = (options?: { init?: boolean }) => {
         }
       } else {
         sharedState.currentDate = new Date(now);
+      }
+
+      const shouldCreateStartReading = !isRecordingActiveFromReadings(
+        readings.sharedState.currentReadings,
+      );
+
+      if (shouldCreateStartReading) {
+        readings.methods.addStartReading();
+      } else {
+        readings.methods.addPauseEndReading();
       }
 
       sharedState.startTime = now - sharedState.elapsedTime * 1000;

--- a/front/src/composables/use-observation/use-readings.ts
+++ b/front/src/composables/use-observation/use-readings.ts
@@ -446,20 +446,21 @@ export const useReadings = (options: {
         }
       }
       
-      // Calculate the exact timestamp based on observation time if provided
+      // Calculate the exact timestamp based on observation time if provided.
       // IMPORTANT: Use getTime() + elapsedTime instead of setMilliseconds() because
-      // setMilliseconds() only accepts 0-999, but elapsedTime can be much larger (seconds/minutes).
-      // Adding milliseconds directly to getTime() handles overflow correctly.
-      // 
-      // NOTE: In chronometer mode, currentDate is already t0 + elapsedTime, so we should NOT
-      // add elapsedTime again. We use currentDate directly if it exists, otherwise fallback
-      // to using elapsedTime with t0 (if in chronometer mode).
+      // setMilliseconds() only accepts 0-999, but elapsedTime can be much larger.
+      //
+      // currentDate est déjà l'horodatage absolu courant dans les deux modes :
+      // - chronomètre : t0 + elapsedTime (mis à jour par updateTimeFromSource)
+      // - calendrier : heure murale réelle (idem)
+      // On l'utilise donc directement. Ajouter elapsedTime en calendrier
+      // double-comptait (currentDate=now puis +elapsed → lecture dans le futur).
       if (options.elapsedTime !== undefined) {
-        // In chronometer mode, allow recording even if currentDate is not initialized
-        // (e.g. clicks before START or while paused).
         const isChronometerMode = observationSharedState?.currentObservation?.mode === 'chronometer';
 
         if (isChronometerMode) {
+          // Autorise l'enregistrement même si currentDate n'est pas initialisé
+          // (clics avant START ou pendant une pause).
           const t0Ms = CHRONOMETER_T0.getTime();
           const dateTimeMs = options.currentDate
             ? options.currentDate.getTime()
@@ -467,10 +468,7 @@ export const useReadings = (options: {
           // Bug 2b.1 : Clamp to t0 minimum - évite les horodatages négatifs (-2ms)
           newReading.dateTime = new Date(Math.max(dateTimeMs, t0Ms));
         } else if (options.currentDate) {
-          // In calendar mode, add elapsedTime to currentDate when currentDate exists
-          newReading.dateTime = new Date(
-            options.currentDate.getTime() + (options.elapsedTime * 1000)
-          );
+          newReading.dateTime = new Date(options.currentDate.getTime());
         }
       }
 

--- a/front/src/pages/userspace/observation/_components/CalendarToolbar.vue
+++ b/front/src/pages/userspace/observation/_components/CalendarToolbar.vue
@@ -57,16 +57,34 @@
       @mode-change="handleModeChange"
     />
 
-    <!-- Timer -->
-    <q-chip color="accent" text-color="white" icon="access_time">
-      {{ observation.timerMethods.formatDuration(observation.sharedState.elapsedTime) }}
-    </q-chip>
+    <!-- Timer : en mode calendrier on affiche l'heure réelle (qui défile en
+         continu, y compris en pause) plutôt qu'un chrono qui repart de zéro.
+         En mode chronomètre on garde la durée écoulée. -->
+    <div class="timer-chip-wrapper">
+      <q-chip color="accent" text-color="white" icon="access_time">
+        {{
+          currentMode === 'calendar'
+            ? liveClockLabel
+            : observation.timerMethods.formatDuration(observation.sharedState.elapsedTime)
+        }}
+      </q-chip>
+      <!-- Voile "En pause" sur l'horloge, cohérent avec celui du dashboard de
+           boutons : l'heure continue de défiler dessous, le voile rappelle
+           juste que l'observation (et l'enregistrement des relevés) est en
+           pause. -->
+      <div
+        v-if="currentMode === 'calendar' && isPausedState"
+        class="timer-paused-veil"
+      >
+        <q-icon name="lock" size="12px" />
+      </div>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref } from 'vue';
-import { useQuasar } from 'quasar';
+import { defineComponent, computed, ref, onMounted, onUnmounted } from 'vue';
+import { useQuasar, date as qDate } from 'quasar';
 import { useI18n } from 'vue-i18n';
 import { useObservation } from 'src/composables/use-observation';
 import { ObservationModeEnum, ReadingTypeEnum } from '@services/observations/interface';
@@ -84,6 +102,26 @@ export default defineComponent({
     const $q = useQuasar();
     const { t } = useI18n();
     const attachInProgress = ref(false);
+
+    // Horloge murale (mode calendrier) : indépendante de elapsedTime/isPlaying
+    // pour continuer à défiler pendant la pause, où l'intervalle du chrono de
+    // l'observation est arrêté (cf. pauseTimer dans use-observation).
+    const now = ref(new Date());
+    let clockIntervalId: number | null = null;
+    const liveClockLabel = computed(() => qDate.formatDate(now.value, 'HH:mm:ss'));
+
+    onMounted(() => {
+      clockIntervalId = window.setInterval(() => {
+        now.value = new Date();
+      }, 1000);
+    });
+
+    onUnmounted(() => {
+      if (clockIntervalId !== null) {
+        clearInterval(clockIntervalId);
+        clockIntervalId = null;
+      }
+    });
 
     /**
      * Récupère le mode actuel de l'observation
@@ -228,6 +266,7 @@ export default defineComponent({
       canChangeMode,
       isObservationActive,
       isPausedState,
+      liveClockLabel,
       attachInProgress,
       showAttachVideo,
       attachVideoBlocked,
@@ -252,16 +291,60 @@ export default defineComponent({
 
 /* Badge "En pause" : ambre, volontairement distinct du bleu (bouton lecture
    / reprendre) et du rouge (bouton pause pendant l'enregistrement actif),
-   pour ne jamais être confondu avec la couleur habituelle de reprise. */
+   pour ne jamais être confondu avec la couleur habituelle de reprise.
+   Clignotement : signale que l'écran n'est pas figé (l'observation reste en
+   pause tant qu'on ne clique pas sur reprendre). */
 .paused-badge {
   background-color: #fac775 !important;
   color: #412402 !important;
   font-weight: 500;
+  animation: paused-badge-blink 1.4s ease-in-out infinite;
 }
 
 .body--dark .paused-badge {
   background-color: #854f0b !important;
   color: #faeeda !important;
+}
+
+@keyframes paused-badge-blink {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .paused-badge {
+    animation: none;
+  }
+}
+
+/* Horloge (mode calendrier) + voile de pause : le chiffre continue de
+   défiler derrière le voile, qui rappelle juste visuellement l'état pause,
+   avec les mêmes teintes ambre que le badge et le voile du dashboard de
+   boutons (buttons-side/Index.vue). */
+.timer-chip-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.timer-paused-veil {
+  position: absolute;
+  inset: -2px;
+  border-radius: 16px;
+  background-color: rgba(250, 199, 117, 0.55);
+  color: #412402;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.body--dark .timer-paused-veil {
+  background-color: rgba(133, 79, 11, 0.6);
+  color: #faeeda;
 }
 </style>
 


### PR DESCRIPTION
## Résumé

En mode calendrier, la barre d'outils d'observation avait trois problèmes liés à la pause :

- Le compteur en haut à droite affichait un chrono qui repartait de zéro (décalé de l'heure réelle des relevés) au lieu de l'heure courante.
- Le compteur se figeait pendant la pause, sans indication visuelle claire que l'observation était en pause.
- Le relevé "fin de pause" enregistrait l'heure de mise en pause au lieu de l'heure de reprise (bug dans `currentDate`, jamais remis à jour à la reprise, seulement au tout premier démarrage).
- Le badge ambre "En pause" ne clignotait pas, ce qui pouvait laisser penser que l'écran était figé.

## Changements

- `CalendarToolbar.vue` : en mode calendrier, le chip horaire affiche désormais l'heure réelle (`HH:mm:ss`, rafraîchie chaque seconde via son propre intervalle, indépendant du chrono de l'observation). Un voile ambre semi-transparent s'affiche par-dessus pendant la pause (même code couleur que le voile déjà utilisé sur le tableau de bord des boutons), sans bloquer le défilement de l'heure en dessous. Le mode chronomètre garde l'affichage en durée écoulée, inchangé.
- `use-observation/index.ts` (`startTimer`) : `currentDate` est maintenant remis à l'heure réelle à chaque (re)démarrage en mode calendrier, y compris à la reprise après pause — avant l'enregistrement du relevé "fin de pause", qui prend donc la bonne heure.
- Badge "En pause" : ajout d'une animation de clignotement (désactivée si `prefers-reduced-motion`).

## Test plan

- [ ] Démarrer une observation en mode calendrier, vérifier que le compteur affiche l'heure réelle et avance en continu
- [ ] Mettre en pause : vérifier que le voile ambre apparaît sur le compteur, que l'heure continue de défiler dessous, et que le badge "En pause" clignote
- [ ] Reprendre après quelques secondes : vérifier dans la liste des relevés que "fin de pause" correspond bien à l'heure de la reprise, pas à l'heure de la mise en pause
- [ ] Vérifier qu'en mode chronomètre l'affichage reste une durée (inchangé) et ne clignote/ne se voile pas

🤖 Generated with [Claude Code](https://claude.com/claude-code)
