### PR TITLE
fix(example): mode calendrier et recalage des dates pour l'exemple café

### DIFF
--- a/api/src/core/observations/services/observation/example.ts
+++ b/api/src/core/observations/services/observation/example.ts
@@ -6,7 +6,7 @@ import { ActivityGraphService } from '../activity-graph.service';
 import { ProtocolService } from '../protocol/index.service';
 import { ReadingService } from '../reading.service';
 import { ObservationService } from './index.service';
-import { ObservationType, ReadingTypeEnum, ProtocolItemActionEnum } from '@actograph/core';
+import { ObservationType, ObservationModeEnum, ReadingTypeEnum, ProtocolItemActionEnum } from '@actograph/core';
 import { NotFoundException } from '@nestjs/common';
 
 interface ExampleDefinition {
@@ -30,7 +30,7 @@ export class Example {
     },
     {
       key: 'faire-le-cafe',
-      version: 'v0.0.1',
+      version: 'v0.0.2',
       create: () => this.createFaireLeCafeExampleObservation(),
     },
   ];
@@ -287,9 +287,10 @@ export class Example {
     // First create the observation entity
     const observationObj = this.observationRepository.create({
       name: 'Exemple Faire le café',
-      description: 'Exemple Faire le café. v0.0.1',
+      description: 'Exemple Faire le café. v0.0.2',
       type: ObservationType.Example,
       exampleKey: 'faire-le-cafe',
+      mode: ObservationModeEnum.Calendar,
     });
 
     // Save the observation in the db

--- a/api/src/core/observations/services/observation/index.service.ts
+++ b/api/src/core/observations/services/observation/index.service.ts
@@ -190,6 +190,10 @@ export class ObservationService extends BaseService<
     await this.readingService.cloneAndAttributeToObservation({
       observationIdToCopyFrom: observation.id,
       observationIdToCopyTo: clonedObservation.id,
+      // Pour les chroniques exemples, recale les relevés démo sur "maintenant"
+      // afin que les relevés ajoutés ensuite par l'utilisateur (horodatés en
+      // temps réel) tombent juste après, plutôt qu'à des mois/années d'écart.
+      rebaseLastReadingToNow: observation.type === ObservationType.Example,
     });
 
     return clonedObservation;

--- a/api/src/core/observations/services/reading.service.ts
+++ b/api/src/core/observations/services/reading.service.ts
@@ -140,6 +140,14 @@ export class ReadingService extends BaseService<Reading, ReadingRepository> {
   public async cloneAndAttributeToObservation(options: {
     observationIdToCopyFrom: number;
     observationIdToCopyTo: number;
+    // Si vrai, décale toutes les dates des relevés clonés pour que le
+    // dernier relevé (le plus tardif) tombe à l'instant de la copie.
+    // Utilisé pour les chroniques exemples : ainsi, tout relevé ajouté
+    // ensuite par l'utilisateur (horodaté avec l'heure réelle) tombe
+    // juste après les relevés de démonstration, au lieu d'en être
+    // séparé par l'écart entre la date de création de l'exemple et
+    // aujourd'hui.
+    rebaseLastReadingToNow?: boolean;
   }) {
     // Find the readings to clone
     const readings = await this.readingRepository.find({
@@ -147,6 +155,14 @@ export class ReadingService extends BaseService<Reading, ReadingRepository> {
     });
     if (readings.length === 0) {
       return;
+    }
+
+    let offsetMs = 0;
+    if (options.rebaseLastReadingToNow) {
+      const lastReadingTime = Math.max(
+        ...readings.map((r) => new Date(r.dateTime).getTime()),
+      );
+      offsetMs = Date.now() - lastReadingTime;
     }
 
     // Clone the readings
@@ -157,7 +173,9 @@ export class ReadingService extends BaseService<Reading, ReadingRepository> {
           description: r.description ?? '',
           observationId: options.observationIdToCopyTo,
           type: r.type,
-          dateTime: r.dateTime,
+          dateTime: offsetMs
+            ? new Date(new Date(r.dateTime).getTime() + offsetMs)
+            : r.dateTime,
         };
       }),
     );

--- a/api/src/core/observations/services/reading.service.ts
+++ b/api/src/core/observations/services/reading.service.ts
@@ -173,7 +173,7 @@ export class ReadingService extends BaseService<Reading, ReadingRepository> {
           description: r.description ?? '',
           observationId: options.observationIdToCopyTo,
           type: r.type,
-          dateTime: offsetMs
+          dateTime: options.rebaseLastReadingToNow
             ? new Date(new Date(r.dateTime).getTime() + offsetMs)
             : r.dateTime,
         };

--- a/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
+++ b/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
@@ -958,8 +958,13 @@ export default defineComponent({
     min-width: 0; // Important pour permettre le scroll
   }
   
+  // Quasar force opacity: 0 !important + pointer-events: none via .q-scrollarea__thumb--invisible
+  // (voir node_modules/quasar/src/components/scroll-area/QScrollArea.sass) : sans !important ici,
+  // la barre horizontale reste invisible et non cliquable au repos, rendant la colonne "support"
+  // (dernière colonne de la grille, hors champ en mode compact) impossible à atteindre.
   :deep(.q-scrollarea__thumb) {
-    opacity: 1;
+    opacity: 1 !important;
+    pointer-events: auto !important;
   }
 }
 


### PR DESCRIPTION
## Résumé
- L'observation exemple "Faire le café" n'avait pas de mode d'observation défini ; elle passe maintenant explicitement en mode Calendrier (bump de version pour forcer le re-seed).
- Les relevés de démonstration étaient figés au 1er janvier 2025. Tout relevé ajouté ensuite par un utilisateur (horodaté en temps réel) se retrouvait donc à des mois/années d'écart sur le graphique, rendant les deux groupes de points illisibles ensemble.
- `cloneAndAttributeToObservation()` peut désormais recaler les dates des relevés clonés sur "maintenant" (option `rebaseLastReadingToNow`), en alignant le **dernier** relevé sur l'instant de la copie. Ainsi, tout relevé ajouté par l'utilisateur juste après tombe naturellement après les relevés de démo.
- Ce recalage n'est activé que lorsque la chronique source est une chronique **exemple** ; la duplication d'une vraie chronique utilisateur n'est pas affectée.

## Plan de test
- [ ] Redémarrer l'API pour déclencher le re-seed de l'exemple "Faire le café" (version bumpée à v0.0.2)
- [ ] Vérifier que l'observation exemple est bien en mode Calendrier
- [ ] Copier l'exemple dans un compte utilisateur et vérifier que le dernier relevé de démo est horodaté à l'instant de la copie
- [ ] Ajouter un nouveau relevé après la copie et vérifier qu'il apparaît juste après les relevés de démo sur le graphique
