### PR TITLE
fix(graph-Arrièreplan une catégorie): rendre la barre de defilement horizontale du tiroir visible et cliquable

### DIFF
--- a/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
+++ b/front/src/pages/userspace/analyse/_components/graph-customization-drawer/Index.vue
@@ -958,8 +958,13 @@ export default defineComponent({
     min-width: 0; // Important pour permettre le scroll
   }
   
+  // Quasar force opacity: 0 !important + pointer-events: none via .q-scrollarea__thumb--invisible
+  // (voir node_modules/quasar/src/components/scroll-area/QScrollArea.sass) : sans !important ici,
+  // la barre horizontale reste invisible et non cliquable au repos, rendant la colonne "support"
+  // (dernière colonne de la grille, hors champ en mode compact) impossible à atteindre.
   :deep(.q-scrollarea__thumb) {
-    opacity: 1;
+    opacity: 1 !important;
+    pointer-events: auto !important;
   }
 }
 


### PR DESCRIPTION
## Probleme

Dans le mode d'affichage "Arriere-plan" du graphe, le selecteur de "support" (choisir Tout / une autre categorie pour scoper la bande d'arriere-plan) est correctement implemente cote logique, mais il est positionne dans la derniere colonne d'une grille CSS a largeur fixe (~636px) alors que le panneau du tiroir en mode compact ne fait souvent que ~340px de large. Il faut donc defiler horizontalement pour l'atteindre.

Ce defilement etait techniquement active (`overflow-x: auto`), mais la barre de defilement elle-meme restait invisible et non cliquable : Quasar applique `opacity: 0 !important; pointer-events: none;` via sa classe `.q-scrollarea__thumb--invisible` (voir `node_modules/quasar/src/components/scroll-area/QScrollArea.sass`), et l'override du composant (`opacity: 1` sans `!important`) ne pouvait pas gagner contre une regle `!important`.

Resultat pour l'utilisateur : le selecteur de support existe mais est hors champ, sans aucun indice qu'il faille defiler pour l'atteindre — d'ou l'impression qu'"il n'y a pas de choix deroulant" sur le mode Arriere-plan.

## Correctif

Ajout de `!important` sur l'override du composant pour qu'il gagne effectivement contre la regle Quasar :

```scss
:deep(.q-scrollarea__thumb) {
  opacity: 1 !important;
  pointer-events: auto !important;
}
```

Verifie en live (HMR) : la barre de defilement horizontale du tiroir de personnalisation passe de `opacity: 0 / pointer-events: none` a `opacity: 1 / pointer-events: auto`, sans affecter les autres barres de defilement de l'app (regle scopee a `.drawer-content`).

## A tester manuellement

- Mettre une categorie en mode "Arriere-plan" dans le tiroir de personnalisation du graphe (protocole avec au moins 3 categories pour un test significatif).
- Verifier que la barre de defilement horizontale du tiroir est maintenant visible et utilisable pour atteindre la colonne "support".
- Choisir une categorie specifique comme support et verifier que le menu deroulant propose bien les autres categories.

🤖 Genere avec [Claude Code](https://claude.com/claude-code)