### PR TITLE
fix(graph): coalescer les redessins déclenchés par un resize du canvas

### DIFF
--- a/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
+++ b/front/src/pages/userspace/analyse/_components/graph/use-graph.ts
@@ -246,7 +246,14 @@ export const useGraph = (options?: {
     }
     const didResize = sharedState.pixiApp.resizeFromCanvas({ skipRender: true });
     if (didResize) {
-      void redrawFromObservation(sharedState.pixiApp);
+      // Coalescé (comme scheduleRedraw) : un drag de volet ou un relayout de
+      // splitter émet une rafale de resize (ResizeObserver). Un redraw complet
+      // immédiat par tick faisait s'enchaîner/se chevaucher des cycles
+      // setData+draw concurrents, laissant l'état des axes/labels incohérent
+      // (labels manquants ou d'une autre catégorie) une fois la rafale
+      // terminée. On ne redessine donc qu'une fois, 50 ms après le dernier
+      // resize.
+      scheduleRedraw();
     }
   };
 


### PR DESCRIPTION
## Contexte

Bug remonté par une testeuse : après avoir redimensionné/déplacé la vue du graphe puis changé d'onglet (Observation -> Graphe), l'affichage revenait dans un état incomplet (étiquettes d'axe manquantes), puis clignotait en continu au survol de la souris. Séparément, glisser le volet de personnalisation (couleurs) faisait passer le graphe entièrement noir pendant le glissé.

## Cause

Chaque changement de taille du canvas (drag du volet, réagencement du splitter après un changement d'onglet) déclenchait un redessin complet **immédiat et non regroupé** (`onCanvasResize` -> `redrawFromObservation` direct). En rafale (drag continu, relayout sur plusieurs frames), ces cycles `setData` + `draw` s'enchaînaient/se chevauchaient :
- le buffer WebGL était vidé (`renderer.resize`) plus vite qu'il n'était repeint -> canvas noir pendant le drag ;
- `axesGraphicsDirty` restait `true` assez longtemps pour que chaque mouvement de souris (`processPointerMove`) relance lui-même un redessin complet -> clignotement continu et état incohérent des étiquettes une fois la rafale terminée (labels manquants en haut/bas selon l'instant où le rendu se stabilisait).

## Correctif

`onCanvasResize` planifie désormais le redessin via `scheduleRedraw()` (coalescence 50 ms), le même mécanisme déjà utilisé pour les mises à jour de protocole/relevés, au lieu de lancer un `redrawFromObservation` immédiat à chaque tick de resize.

## Test

- `vue-tsc --noEmit` : 0 erreur.
- Non vérifié visuellement en conditions réelles (nécessite l'app Electron + données réelles) : à confirmer par la testeuse sur le scénario exact (redimensionner l'axe -> changer d'onglet -> revenir -> survoler le graphe ; puis glisser le volet de personnalisation).