### PR TITLE
fix(graph): rendre les segments de frise opaques

### DIFF
--- a/packages/graph/src/pixi-app/data-area/index.ts
+++ b/packages/graph/src/pixi-app/data-area/index.ts
@@ -1119,7 +1119,7 @@ export class DataArea extends BaseGroup {
       if (pattern === BackgroundPatternEnum.Solid) {
         graphic
           .rect(segmentStartX, friezeTopY, segmentWidth, friezeHeight)
-          .fill({ color, alpha: 0.6 });
+          .fill({ color, alpha: 1 });
 
         graphic
           .rect(segmentStartX, friezeTopY, segmentWidth, friezeHeight)


### PR DESCRIPTION
## Résumé
- Les segments de la frise (catégories continues) étaient dessinés avec `alpha: 0.6`, ce qui les rendait translucides et faisait fusionner leur couleur avec le fond du graphe — les couleurs devenaient délavées et illisibles, surtout entre segments adjacents.
- Passage à `alpha: 1` pour un rendu plein/opaque, conforme à la couleur choisie dans le panneau "Graphe".

## Test plan
- [ ] Ouvrir une chronique avec plusieurs catégories continues colorées sur la frise (ex. Cat. LIEU)
- [ ] Vérifier que chaque segment affiche sa couleur pleine, sans mélange avec le fond
- [ ] Vérifier que les segments à motif (hachures/points) ne sont pas affectés (rendu inchangé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)