### PR TITLE
fix(graph): stopper les états en mode calendrier pendant les pauses

### DIFF
--- a/packages/graph/src/__tests__/continuous-segments.utils.test.ts
+++ b/packages/graph/src/__tests__/continuous-segments.utils.test.ts
@@ -232,7 +232,7 @@ describe('continuous-segments.utils', () => {
   });
 
   describe('setData pipeline simulation', () => {
-    it('keeps one continuous segment after merge when pauses are present', () => {
+    it('keeps one continuous segment after merge when pauses are present (chronometer mode)', () => {
       const sortedReadings = [
         mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:10:00Z'), name: 'obs1' }),
         mk({ type: ReadingTypeEnum.PAUSE_START, dateTime: new Date('2024-01-01T10:20:00Z') }),
@@ -246,6 +246,42 @@ describe('continuous-segments.utils', () => {
 
       expect(getContinuousSegmentStartIndices(merged)).toEqual([0]);
       expect(iterContinuousDataPairs(merged)).toHaveLength(1);
+    });
+
+    it('breaks the segment at the pause in calendar mode (treatPauseAsBoundary)', () => {
+      const sortedReadings = [
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:10:00Z'), name: 'obs1' }),
+        mk({ type: ReadingTypeEnum.PAUSE_START, dateTime: new Date('2024-01-01T10:20:00Z') }),
+        mk({ type: ReadingTypeEnum.PAUSE_END, dateTime: new Date('2024-01-01T10:25:00Z') }),
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:30:00Z'), name: 'obs1' }),
+      ];
+
+      const categoryData = sortedReadings.filter((r) => r.type === ReadingTypeEnum.DATA);
+      const boundaries = extractSessionBoundaryReadings(sortedReadings, true);
+      const merged = mergeContinuousCategoryReadings(categoryData, boundaries);
+
+      // merged = [DATA, PAUSE_START, PAUSE_END, DATA]; second segment starts at index 3.
+      expect(getContinuousSegmentStartIndices(merged, true)).toEqual([0, 3]);
+
+      const pairs = iterContinuousDataPairs(merged, true);
+      expect(pairs).toHaveLength(1);
+      expect(pairs[0]?.from.dateTime).toEqual(new Date('2024-01-01T10:10:00Z'));
+      expect(pairs[0]?.to.dateTime).toEqual(new Date('2024-01-01T10:20:00Z'));
+    });
+
+    it('keeps an ongoing pause (no PAUSE_END yet) frozen at PAUSE_START in calendar mode', () => {
+      const sortedReadings = [
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:10:00Z'), name: 'obs1' }),
+        mk({ type: ReadingTypeEnum.PAUSE_START, dateTime: new Date('2024-01-01T10:20:00Z') }),
+      ];
+
+      const categoryData = sortedReadings.filter((r) => r.type === ReadingTypeEnum.DATA);
+      const boundaries = extractSessionBoundaryReadings(sortedReadings, true);
+      const merged = mergeContinuousCategoryReadings(categoryData, boundaries);
+
+      const pairs = iterContinuousDataPairs(merged, true);
+      expect(pairs).toHaveLength(1);
+      expect(pairs[0]?.to.dateTime).toEqual(new Date('2024-01-01T10:20:00Z'));
     });
   });
 });

--- a/packages/graph/src/__tests__/continuous-segments.utils.test.ts
+++ b/packages/graph/src/__tests__/continuous-segments.utils.test.ts
@@ -127,6 +127,23 @@ describe('continuous-segments.utils', () => {
       expect(shouldSkipInContinuousDraw(pauseEnd, stop1)).toBe(true);
       expect(shouldSkipInContinuousDraw(stop1, undefined)).toBe(false);
     });
+
+    it('calendar mode: draws PAUSE_START after DATA but skips trailing boundary markers', () => {
+      const data = mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:10:00Z') });
+      const pauseStart = mk({
+        type: ReadingTypeEnum.PAUSE_START,
+        dateTime: new Date('2024-01-01T10:20:00Z'),
+      });
+      const pauseEnd = mk({
+        type: ReadingTypeEnum.PAUSE_END,
+        dateTime: new Date('2024-01-01T10:25:00Z'),
+      });
+      const stop = mk({ type: ReadingTypeEnum.STOP, dateTime: new Date('2024-01-01T10:30:00Z') });
+
+      expect(shouldSkipInContinuousDraw(pauseStart, data, true)).toBe(false);
+      expect(shouldSkipInContinuousDraw(pauseEnd, pauseStart, true)).toBe(true);
+      expect(shouldSkipInContinuousDraw(stop, pauseStart, true)).toBe(true);
+    });
   });
 
   describe('getContinuousSegmentStartIndices', () => {
@@ -169,6 +186,28 @@ describe('continuous-segments.utils', () => {
       );
       expect(getContinuousSegmentStartIndices(merged)).toEqual([0]);
       expect(merged[0]?.type).toBe(ReadingTypeEnum.DATA);
+    });
+
+    it('calendar mode: splits at each PAUSE_START between DATA readings', () => {
+      const sortedReadings = [
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:10:00Z') }),
+        mk({ type: ReadingTypeEnum.PAUSE_START, dateTime: new Date('2024-01-01T10:20:00Z') }),
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:30:00Z') }),
+        mk({ type: ReadingTypeEnum.PAUSE_START, dateTime: new Date('2024-01-01T10:40:00Z') }),
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:50:00Z') }),
+      ];
+      const categoryData = sortedReadings.filter((r) => r.type === ReadingTypeEnum.DATA);
+      const boundaries = extractSessionBoundaryReadings(sortedReadings, true);
+      const merged = mergeContinuousCategoryReadings(categoryData, boundaries);
+
+      expect(merged.map((r) => r.type)).toEqual([
+        ReadingTypeEnum.DATA,
+        ReadingTypeEnum.PAUSE_START,
+        ReadingTypeEnum.DATA,
+        ReadingTypeEnum.PAUSE_START,
+        ReadingTypeEnum.DATA,
+      ]);
+      expect(getContinuousSegmentStartIndices(merged, true)).toEqual([0, 2, 4]);
     });
   });
 
@@ -228,6 +267,29 @@ describe('continuous-segments.utils', () => {
 
       expect(pairs).toHaveLength(1);
       expect(pairs[0]?.to.dateTime).toEqual(new Date('2024-01-01T10:15:00Z'));
+    });
+
+    it('calendar mode: pairs each segment to its boundary without bridging pauses', () => {
+      const sortedReadings = [
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:10:00Z') }),
+        mk({ type: ReadingTypeEnum.PAUSE_START, dateTime: new Date('2024-01-01T10:20:00Z') }),
+        mk({ type: ReadingTypeEnum.PAUSE_END, dateTime: new Date('2024-01-01T10:25:00Z') }),
+        mk({ type: ReadingTypeEnum.DATA, dateTime: new Date('2024-01-01T10:30:00Z') }),
+        mk({ type: ReadingTypeEnum.STOP, dateTime: new Date('2024-01-01T10:40:00Z') }),
+      ];
+      const categoryData = sortedReadings.filter((r) => r.type === ReadingTypeEnum.DATA);
+      const boundaries = extractSessionBoundaryReadings(sortedReadings, true);
+      const merged = mergeContinuousCategoryReadings(categoryData, boundaries);
+
+      const pairs = iterContinuousDataPairs(merged, true);
+
+      expect(pairs).toHaveLength(2);
+      expect(pairs[0]?.from.dateTime).toEqual(new Date('2024-01-01T10:10:00Z'));
+      expect(pairs[0]?.to.dateTime).toEqual(new Date('2024-01-01T10:20:00Z'));
+      expect(pairs[0]?.to.type).toBe(ReadingTypeEnum.PAUSE_START);
+      expect(pairs[1]?.from.dateTime).toEqual(new Date('2024-01-01T10:30:00Z'));
+      expect(pairs[1]?.to.dateTime).toEqual(new Date('2024-01-01T10:40:00Z'));
+      expect(pairs[1]?.to.type).toBe(ReadingTypeEnum.STOP);
     });
   });
 

--- a/packages/graph/src/pixi-app/data-area/index.ts
+++ b/packages/graph/src/pixi-app/data-area/index.ts
@@ -37,6 +37,7 @@ import { createTilingPatternSprite } from '../../lib/pattern-textures';
 import {
   extractSessionBoundaryReadings,
   getContinuousSegmentStartIndices,
+  isBoundaryReadingType,
   iterContinuousDataPairs,
   mergeContinuousCategoryReadings,
   shouldSkipInContinuousDraw,
@@ -84,6 +85,12 @@ export class DataArea extends BaseGroup {
 
   private protocol: IProtocol | null = null;
   protected observation: IObservation | null = null;
+  // Calendar mode: readings carry real wall-clock timestamps, so an open
+  // pause still spans real time and must break a continuous segment (like a
+  // STOP does) or the state would appear to run straight through the pause.
+  // Chronometer mode freezes elapsed time during a pause, so bridging over it
+  // is correct there and left untouched.
+  private treatPauseAsSegmentBoundary = false;
   private pausePeriods: IPeriod[] = [];
   private graphRenderOptions: IGraphRenderOptions = { ...DEFAULT_GRAPH_RENDER_OPTIONS };
   private hoverOverlaySuppressed = false;
@@ -436,6 +443,8 @@ export class DataArea extends BaseGroup {
   public setData(observation: IObservation) {
     super.setData(observation);
     this.observation = observation;
+    this.treatPauseAsSegmentBoundary =
+      observation.mode !== ObservationModeEnum.Chronometer;
 
     const protocol = observation.protocol;
     if (!protocol) {
@@ -481,7 +490,10 @@ export class DataArea extends BaseGroup {
       }
     }
 
-    const sessionBoundaryReadings = extractSessionBoundaryReadings(sortedReadings);
+    const sessionBoundaryReadings = extractSessionBoundaryReadings(
+      sortedReadings,
+      this.treatPauseAsSegmentBoundary,
+    );
 
     for (const categoryEntry of this.readingsPerCategory) {
       const isContinuous = !categoryEntry.category.action ||
@@ -784,7 +796,9 @@ export class DataArea extends BaseGroup {
       }
       const axisEndX = xAxisEnd.x;
       const newSegmentIndices = new Set(
-        getContinuousSegmentStartIndices(readings).filter((idx) => idx > 0),
+        getContinuousSegmentStartIndices(readings, this.treatPauseAsSegmentBoundary).filter(
+          (idx) => idx > 0,
+        ),
       );
 
       graphic.clear();
@@ -795,7 +809,7 @@ export class DataArea extends BaseGroup {
 
         const previousReading = readings[i - 1];
 
-        if (shouldSkipInContinuousDraw(reading, previousReading)) {
+        if (shouldSkipInContinuousDraw(reading, previousReading, this.treatPauseAsSegmentBoundary)) {
           continue;
         }
 
@@ -818,10 +832,9 @@ export class DataArea extends BaseGroup {
           continue;
         }
 
-        const yPos =
-          reading.type === ReadingTypeEnum.STOP
-            ? -1
-            : this.getYPosForReading(category, reading.name || '');
+        const yPos = isBoundaryReadingType(reading.type, this.treatPauseAsSegmentBoundary)
+          ? -1
+          : this.getYPosForReading(category, reading.name || '');
 
         // Consecutive readings can share the same timestamp (mobile taps in same second).
         // Without a minimum spacing, segments collapse to zero width and look "missing".
@@ -918,7 +931,7 @@ export class DataArea extends BaseGroup {
     graphic.clear();
     this.clearTilingSpritesForCategory(category);
 
-    for (const { from, to } of iterContinuousDataPairs(readings)) {
+    for (const { from, to } of iterContinuousDataPairs(readings, this.treatPauseAsSegmentBoundary)) {
       const startX = this.xAxis.getPosFromDateTime(from.dateTime);
       const endX = this.xAxis.getPosFromDateTime(to.dateTime);
       const zoneWidth = endX - startX;
@@ -1102,7 +1115,7 @@ export class DataArea extends BaseGroup {
     const friezeTopY = friezeInfo.endY;
     const friezeHeight = friezeInfo.height;
 
-    for (const { from, to } of iterContinuousDataPairs(readings)) {
+    for (const { from, to } of iterContinuousDataPairs(readings, this.treatPauseAsSegmentBoundary)) {
       const segmentStartX = this.xAxis.getPosFromDateTime(from.dateTime);
       const segmentEndX = this.xAxis.getPosFromDateTime(to.dateTime);
       const segmentWidth = segmentEndX - segmentStartX;

--- a/packages/graph/src/utils/continuous-segments.utils.ts
+++ b/packages/graph/src/utils/continuous-segments.utils.ts
@@ -11,15 +11,35 @@ function sortReadingsByTime(readings: IReading[]): IReading[] {
     .sort((a, b) => getReadingTimeMs(a) - getReadingTimeMs(b));
 }
 
-/** Global STOP markers injected into every continuous category. */
-export function extractSessionBoundaryReadings(readings: IReading[]): IReading[] {
-  return sortReadingsByTime(readings).filter(
-    (reading) => reading.type === ReadingTypeEnum.STOP,
+/**
+ * STOP always breaks a segment. In calendar mode, an open pause spans real
+ * wall-clock time (unlike chronometer mode, where elapsed time is frozen
+ * during a pause), so PAUSE_START/PAUSE_END must break segments too —
+ * otherwise the state drawn before the pause silently bridges across it.
+ */
+function isBoundaryReadingType(
+  type: IReading['type'],
+  treatPauseAsBoundary: boolean,
+): boolean {
+  return (
+    type === ReadingTypeEnum.STOP ||
+    (treatPauseAsBoundary &&
+      (type === ReadingTypeEnum.PAUSE_START || type === ReadingTypeEnum.PAUSE_END))
+  );
+}
+
+/** Global STOP (and, in calendar mode, pause) markers injected into every continuous category. */
+export function extractSessionBoundaryReadings(
+  readings: IReading[],
+  treatPauseAsBoundary = false,
+): IReading[] {
+  return sortReadingsByTime(readings).filter((reading) =>
+    isBoundaryReadingType(reading.type, treatPauseAsBoundary),
   );
 }
 
 /**
- * Merges category DATA readings with global STOP markers and trims
+ * Merges category DATA readings with global boundary markers and trims
  * entries before the first DATA (e.g. leading STOP markers).
  */
 export function mergeContinuousCategoryReadings(
@@ -40,21 +60,25 @@ export function mergeContinuousCategoryReadings(
 export function isNewSessionWithoutBridge(
   reading: IReading,
   previousReading: IReading | undefined,
+  treatPauseAsBoundary = false,
 ): boolean {
   return (
     reading.type === ReadingTypeEnum.DATA &&
-    previousReading?.type === ReadingTypeEnum.STOP
+    !!previousReading &&
+    isBoundaryReadingType(previousReading.type, treatPauseAsBoundary)
   );
 }
 
-/** True when a consecutive STOP should be skipped during continuous rendering. */
+/** True when a consecutive boundary reading should be skipped during continuous rendering. */
 export function shouldSkipConsecutiveStop(
   reading: IReading,
   previousReading: IReading | undefined,
+  treatPauseAsBoundary = false,
 ): boolean {
   return (
-    reading.type === ReadingTypeEnum.STOP &&
-    previousReading?.type === ReadingTypeEnum.STOP
+    !!previousReading &&
+    isBoundaryReadingType(reading.type, treatPauseAsBoundary) &&
+    isBoundaryReadingType(previousReading.type, treatPauseAsBoundary)
   );
 }
 
@@ -62,10 +86,16 @@ export function shouldSkipConsecutiveStop(
 export function shouldSkipInContinuousDraw(
   reading: IReading,
   previousReading: IReading | undefined,
+  treatPauseAsBoundary = false,
 ): boolean {
-  if (shouldSkipConsecutiveStop(reading, previousReading)) {
+  if (shouldSkipConsecutiveStop(reading, previousReading, treatPauseAsBoundary)) {
     return true;
   }
+  if (treatPauseAsBoundary) {
+    return false;
+  }
+  // Legacy behaviour (chronometer mode): pauses never break a segment, so
+  // pause markers are simply ignored during rendering.
   return (
     reading.type === ReadingTypeEnum.PAUSE_START ||
     reading.type === ReadingTypeEnum.PAUSE_END
@@ -74,9 +104,13 @@ export function shouldSkipInContinuousDraw(
 
 /**
  * Returns indices where a new continuous segment starts (first DATA, then each
- * DATA after STOP without bridge). Pauses do not split segments.
+ * DATA after a boundary reading without bridge). With treatPauseAsBoundary,
+ * an open pause splits segments the same way a STOP does.
  */
-export function getContinuousSegmentStartIndices(readings: IReading[]): number[] {
+export function getContinuousSegmentStartIndices(
+  readings: IReading[],
+  treatPauseAsBoundary = false,
+): number[] {
   const firstDataIndex = readings.findIndex(
     (reading) => reading.type === ReadingTypeEnum.DATA,
   );
@@ -93,11 +127,11 @@ export function getContinuousSegmentStartIndices(readings: IReading[]): number[]
       continue;
     }
 
-    if (shouldSkipInContinuousDraw(reading, previousReading)) {
+    if (shouldSkipInContinuousDraw(reading, previousReading, treatPauseAsBoundary)) {
       continue;
     }
 
-    if (isNewSessionWithoutBridge(reading, previousReading)) {
+    if (isNewSessionWithoutBridge(reading, previousReading, treatPauseAsBoundary)) {
       starts.push(i);
     }
   }
@@ -107,17 +141,17 @@ export function getContinuousSegmentStartIndices(readings: IReading[]): number[]
 
 /**
  * Consecutive DATA pairs within the same continuous segment (no bridge across
- * STOP). Pauses are ignored and do not break pairing. Used for background and
- * frieze rendering.
+ * a boundary). Used for background and frieze rendering.
  *
- * The last DATA of a segment is also paired with the segment's closing STOP
- * (session end or pause), so the final state is drawn through to that
- * boundary instead of disappearing.
+ * The last DATA of a segment is also paired with the segment's closing
+ * boundary (session end or, in calendar mode, pause start), so the final
+ * state is drawn through to that boundary instead of disappearing.
  */
 export function iterContinuousDataPairs(
   readings: IReading[],
+  treatPauseAsBoundary = false,
 ): Array<{ from: IReading; to: IReading }> {
-  const starts = getContinuousSegmentStartIndices(readings);
+  const starts = getContinuousSegmentStartIndices(readings, treatPauseAsBoundary);
   const pairs: Array<{ from: IReading; to: IReading }> = [];
 
   for (let s = 0; s < starts.length; s++) {
@@ -133,9 +167,14 @@ export function iterContinuousDataPairs(
     }
 
     const lastData = dataInSegment[dataInSegment.length - 1];
-    const boundary = [...segmentReadings]
-      .reverse()
-      .find((reading) => reading.type === ReadingTypeEnum.STOP);
+    // Boundary readings only ever trail the last DATA of a segment (a DATA
+    // right after one always starts a new segment), so the first boundary
+    // found scanning forward is also the earliest — e.g. PAUSE_START rather
+    // than the PAUSE_END that closes it out, which is what should end the
+    // drawn state.
+    const boundary = segmentReadings.find((reading) =>
+      isBoundaryReadingType(reading.type, treatPauseAsBoundary),
+    );
     if (lastData && boundary) {
       pairs.push({ from: lastData, to: boundary });
     }
@@ -143,3 +182,6 @@ export function iterContinuousDataPairs(
 
   return pairs;
 }
+
+/** Exported for reuse by drawing code that needs the same boundary semantics. */
+export { isBoundaryReadingType };


### PR DESCRIPTION
## Summary
- En mode calendrier, les segments d'état continus ignoraient les relevés PAUSE_START/PAUSE_END (comme un simple STOP), donc un état actif avant une pause était tracé en continu jusqu'à la reprise, comme s'il avait duré pendant toute la pause.
- Les pauses sont maintenant traitées comme des frontières de segment (au même titre qu'un STOP), mais uniquement en mode calendrier : le mode chronomètre (où le temps écoulé est figé pendant la pause) garde son comportement actuel.
- Fonctionne aussi pour une pause encore en cours (pas encore de PAUSE_END) : l'état s'arrête de se tracer dès le début de la pause.

## Test plan
- [x] Tests unitaires ajoutés dans `continuous-segments.utils.test.ts` couvrant : coupure du segment au pause-start, pause en cours non terminée, non-régression du mode chronomètre.
- [x] Suite complète du package `packages/graph` (81 tests) au vert.
- [x] Typecheck du package (`tsc --project tsconfig.build.json`) au vert.
- [ ] Vérification visuelle manuelle dans l'appli (non effectuée dans cette session, nécessite API + auth).