### PR TITLE
fix(mobile): empêcher le chrono de déborder sous les boutons play/pause/stop

### DIFF
--- a/mobile/src/pages/observation/Index.vue
+++ b/mobile/src/pages/observation/Index.vue
@@ -1361,9 +1361,22 @@ export default defineComponent({
 
 .timer-display {
   font-family: 'Roboto Mono', 'Courier New', monospace;
+  // Se réduit sur les écrans étroits pour garder une marge par rapport aux
+  // boutons play/pause/stop voisins (sinon le texte peut déborder derrière
+  // eux, cf. rapport-bug écran caché par les boutons). 2.125rem = taille
+  // text-h4 par défaut, conservée sur les écrans suffisamment larges.
+  font-size: clamp(22px, 8vw, 2.125rem);
   letter-spacing: 2px;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   line-height: 1.2;
+  // Filet de sécurité : si malgré le clamp le texte reste trop large
+  // (police système agrandie, très petit écran...), il est tronqué
+  // proprement dans sa propre boîte plutôt que de déborder sous les
+  // boutons voisins.
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   &.blink {
     animation: blink-animation 1s ease-in-out infinite;


### PR DESCRIPTION
## Contexte
Retour bêta-test de Valérie (capture d'écran, 28 juillet 2026) : pendant un enregistrement actif, le chronomètre de l'écran d'observation est partiellement caché par les boutons pause/stop.

## Cause
Le chrono (text-h4, 34px) et les 2 boutons de droite se partagent une largeur sans aucune marge (mesuré : 182px de texte pour 182px disponibles à 360px de large). Le moindre facteur supplémentaire (écran plus étroit, police système agrandie) fait déborder le texte, peint sous les boutons voisins (ordre du DOM) au lieu d'être repoussé.

## Changement
- mobile/src/pages/observation/Index.vue (.timer-display)
- font-size en clamp() : réduit sur écrans étroits, taille normale sinon
- Filet de sécurité (overflow hidden + ellipsis + min-width 0) : si le clamp ne suffit pas, dégradation propre en "13:54:..." plutôt qu'un chevauchement silencieux

## Test manuel effectué
Reproduction isolée (CSS Quasar réel, classes identiques) à 360px (cas réel, plus de chevauchement) et 300px + police système +20% (cas extrême, dégradation propre en ellipsis).

## ⚠️ À vérifier avant merge
- [ ] Rendu sur device Android réel (non disponible dans cette session)
- [ ] yarn lint non exécuté (dépendances non installées dans cette session)

## Origine de la demande
Retour de Valérie (bêta-test Actograph V3), capture d'écran du 28 juillet 2026.

---
🤖 Généré avec Claude Code