### PR TITLE
fix(mobile): rendre visible l'enregistrement en cours

### DIFF
--- a/mobile/src/pages/observation/Index.vue
+++ b/mobile/src/pages/observation/Index.vue
@@ -23,6 +23,11 @@
           class="timer-display text-h4 text-weight-bold col text-center"
           :class="chronicle.sharedState.isPaused ? 'text-warning blink' : 'text-accent'"
         >
+          <span
+            v-if="state.isRecording && !chronicle.sharedState.isPaused"
+            class="rec-dot"
+            aria-hidden="true"
+          />
           {{ chronicle.formattedTime.value }}
         </div>
 
@@ -1370,9 +1375,26 @@ export default defineComponent({
   }
 }
 
+.rec-dot {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  margin-right: 6px;
+  margin-bottom: 2px;
+  border-radius: 50%;
+  background: var(--q-negative);
+  vertical-align: middle;
+  animation: rec-dot-pulse 1.1s ease-in-out infinite;
+}
+
 @keyframes blink-animation {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
+}
+
+@keyframes rec-dot-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.35; transform: scale(0.85); }
 }
 
 .categories-container {


### PR DESCRIPTION
## Summary
- Sur mobile, le chrono qui defile pendant l'enregistrement ne suffisait pas a voir d'un coup d'oeil que l'observation etait active (retour beta-test de Valerie).
- Ajout d'un point rouge pulsant a cote du chrono, visible uniquement pendant l'enregistrement actif (`state.isRecording && !chronicle.sharedState.isPaused`).
- Reprend la meme logique que le badge deja ajoute cote web (394e3d5, fix/observation-recording-indicator-visibility).

## Test plan
- [ ] Sylvain : verifier sur build mobile (Android/iOS ou Capacitor) que le point apparait au demarrage de l'enregistrement, disparait en pause et a l'arret.
- [x] CSS verifie en isolation dans un navigateur (couleur `--q-negative`, taille, animation) - le test bout-en-bout n'a pas pu etre fait en navigateur car SQLite (Capacitor) ne s'y initialise pas.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>