### PR TITLE
fix(mobile): corriger le contraste des chiffres et des noms de categorie

### DIFF
--- a/mobile/src/components/DraggableCategory.vue
+++ b/mobile/src/components/DraggableCategory.vue
@@ -464,12 +464,15 @@ export default defineComponent({
 
   &.continuous {
     .category-header {
-      background: rgba(249, 115, 22, 0.12);
-      color: #9a3412;
-      border-bottom-color: rgba(249, 115, 22, 0.18);
+      // Reste plus discret que l'en-tête sombre par défaut (teinte orange
+      // pâle plutôt que --primary plein), mais #7c2d12 (vs #9a3412 avant)
+      // porte le contraste sur fond clair à ~8:1 (AAA) au lieu de ~6:1.
+      background: rgba(249, 115, 22, 0.16);
+      color: #7c2d12;
+      border-bottom-color: rgba(249, 115, 22, 0.22);
 
       .drag-handle {
-        color: #9a3412 !important;
+        color: #7c2d12 !important;
       }
     }
   }

--- a/mobile/src/pages/Index.vue
+++ b/mobile/src/pages/Index.vue
@@ -18,7 +18,7 @@
         <q-card-section class="stats-section">
           <div class="row no-wrap">
             <div class="stat-item col text-center">
-              <div class="text-h4 text-weight-bold text-primary">{{ chronicle.sharedState.currentReadings.length }}</div>
+              <div class="text-h4 text-weight-bold stat-value">{{ chronicle.sharedState.currentReadings.length }}</div>
               <div class="stat-label text-caption">
                 <q-icon name="mdi-database" size="14px" class="q-mr-xs" />
                 Relevés
@@ -26,7 +26,7 @@
             </div>
             <q-separator vertical />
             <div class="stat-item col text-center">
-              <div class="text-h4 text-weight-bold text-primary">{{ chronicle.sharedState.currentProtocol.length }}</div>
+              <div class="text-h4 text-weight-bold stat-value">{{ chronicle.sharedState.currentProtocol.length }}</div>
               <div class="stat-label text-caption">
                 <q-icon name="mdi-folder-outline" size="14px" class="q-mr-xs" />
                 Catégories
@@ -501,6 +501,13 @@ body.body--light .home-action-btn {
 .chronicle-description,
 .stat-label {
   color: var(--text-secondary);
+}
+
+// `.text-primary` (Quasar utility) is hardcoded to the brand color (#1f2937)
+// in both themes, so it's near-invisible on the dark-mode card background.
+// Use the theme-aware --text var instead (black on light, white on dark).
+.stat-value {
+  color: var(--text);
 }
 
 body.body--dark {


### PR DESCRIPTION
## Résumé
- Retour bêta-test (Valérie) : sur l'accueil, les chiffres "Relevés"/"Catégories" utilisaient la classe Quasar `text-primary`, codée en dur sur la couleur de marque (#1f2937) même en thème sombre — quasi invisible sur le fond de carte sombre. Remplacé par `--text` (adapté au thème clair/sombre).
- Sur l'écran d'observation, l'en-tête des catégories continues (fond orange pâle + texte `#9a3412`) restait lisible mais avec une marge de contraste faible (~6:1). Le texte est foncé vers `#7c2d12` et la teinte de fond légèrement renforcée (~8:1), en gardant l'en-tête plus discret que celui des catégories discrètes (fond sombre plein + texte blanc).

## Test plan
- [ ] Vérifier sur mobile (thème clair et sombre) que les chiffres "Relevés"/"Catégories" sont bien lisibles sur l'accueil
- [ ] Vérifier sur l'écran Observation que le nom des catégories continues est lisible tout en restant plus discret que les catégories discrètes

🤖 Generated with Claude Code