### PR TITLE
fix(mobile): intégrer les retours bêta UI (chrono, REC, contraste)

### DIFF
--- a/mobile/src/components/DraggableCategory.vue
+++ b/mobile/src/components/DraggableCategory.vue
@@ -464,12 +464,14 @@ export default defineComponent({
 
   &.continuous {
     .category-header {
-      background: rgba(249, 115, 22, 0.12);
-      color: #9a3412;
-      border-bottom-color: rgba(249, 115, 22, 0.18);
+      // Still softer than discrete headers (full --primary + white), but
+      // #7c2d12 on the slightly stronger orange wash reaches ~8:1 (AAA).
+      background: rgba(249, 115, 22, 0.16);
+      color: #7c2d12;
+      border-bottom-color: rgba(249, 115, 22, 0.22);
 
       .drag-handle {
-        color: #9a3412 !important;
+        color: #7c2d12 !important;
       }
     }
   }

--- a/mobile/src/pages/Index.vue
+++ b/mobile/src/pages/Index.vue
@@ -18,7 +18,7 @@
         <q-card-section class="stats-section">
           <div class="row no-wrap">
             <div class="stat-item col text-center">
-              <div class="text-h4 text-weight-bold text-primary">{{ chronicle.sharedState.currentReadings.length }}</div>
+              <div class="text-h4 text-weight-bold stat-value">{{ chronicle.sharedState.currentReadings.length }}</div>
               <div class="stat-label text-caption">
                 <q-icon name="mdi-database" size="14px" class="q-mr-xs" />
                 Relevés
@@ -26,7 +26,7 @@
             </div>
             <q-separator vertical />
             <div class="stat-item col text-center">
-              <div class="text-h4 text-weight-bold text-primary">{{ chronicle.sharedState.currentProtocol.length }}</div>
+              <div class="text-h4 text-weight-bold stat-value">{{ chronicle.sharedState.currentProtocol.length }}</div>
               <div class="stat-label text-caption">
                 <q-icon name="mdi-folder-outline" size="14px" class="q-mr-xs" />
                 Catégories
@@ -501,6 +501,12 @@ body.body--light .home-action-btn {
 .chronicle-description,
 .stat-label {
   color: var(--text-secondary);
+}
+
+// `.text-primary` is hardcoded to brand (#1f2937) in both themes, so near-invisible
+// on the dark-mode card. Prefer theme-aware --text (black light / white dark).
+.stat-value {
+  color: var(--text);
 }
 
 body.body--dark {

--- a/mobile/src/pages/observation/Index.vue
+++ b/mobile/src/pages/observation/Index.vue
@@ -18,12 +18,18 @@
         />
         <div v-else class="toolbar-spacer" />
 
-        <!-- Center: Timer -->
+        <!-- Center: Timer (+ REC dot while recording) -->
         <div
           class="timer-display text-h4 text-weight-bold col text-center"
           :class="chronicle.sharedState.isPaused ? 'text-warning blink' : 'text-accent'"
+          :aria-label="state.isRecording && !chronicle.sharedState.isPaused ? 'Enregistrement en cours' : undefined"
         >
-          {{ chronicle.formattedTime.value }}
+          <span
+            v-if="state.isRecording && !chronicle.sharedState.isPaused"
+            class="rec-dot"
+            aria-hidden="true"
+          />
+          <span class="timer-text">{{ chronicle.formattedTime.value }}</span>
         </div>
 
         <!-- Right: Edit mode actions OR Record controls -->
@@ -1360,19 +1366,49 @@ export default defineComponent({
 }
 
 .timer-display {
+  // Flex so the REC dot stays visible while only the time text can ellipsize
+  // on narrow screens / large system fonts (avoids painting under pause/stop).
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 0;
   font-family: 'Roboto Mono', 'Courier New', monospace;
+  // 2.125rem = Quasar text-h4; shrink on narrow viewports to keep margin vs buttons.
+  font-size: clamp(22px, 8vw, 2.125rem);
   letter-spacing: 2px;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   line-height: 1.2;
+
+  .timer-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
   &.blink {
     animation: blink-animation 1s ease-in-out infinite;
   }
 }
 
+.rec-dot {
+  flex-shrink: 0;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--q-negative);
+  animation: rec-dot-pulse 1.1s ease-in-out infinite;
+}
+
 @keyframes blink-animation {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
+}
+
+@keyframes rec-dot-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.35; transform: scale(0.85); }
 }
 
 .categories-container {


### PR DESCRIPTION
## Summary
- Remplace les PRs standby #116, #117 et #118 par un patch unique et cohérent (même fichier observation pour #116+#117).
- Chrono observation : `clamp` + ellipsis sur le texte seul (flex), pour ne plus peindre sous pause/stop sur écrans étroits.
- Point rouge REC pendant l'enregistrement actif (`isRecording && !isPaused`), sans être tronqué par l'ellipsis.
- Accueil : stats Relevés/Catégories via `var(--text)` (lisible en dark mode).
- Catégories continues : contraste en-tête renforcé (~8:1).

## Why not merge #116/#117/#118 as-is
- #116 et #117 touchent le même fichier ; un merge naïf aurait mis le REC et l'ellipsis sur le même nœud texte (le point aurait pu être tronqué).
- Layout senior : flex + `.timer-text` dédié.

## Test plan
- [ ] Mobile clair/sombre : chiffres Relevés/Catégories lisibles sur l'accueil
- [ ] Observation : démarrer enregistrement → point REC visible ; pause → disparaît ; stop → disparaît
- [ ] Écran étroit (~360px) : chrono ne passe plus sous pause/stop
- [ ] Catégories continues : noms d'en-tête lisibles, toujours plus discrets que les discrètes

Supersedes #116 #117 #118